### PR TITLE
feat: avoid request recreation

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,10 +286,9 @@ const gw = gateway({
     /**
      * Runs before any endpoint handler logic.
      * @param ctx.request Incoming request.
-     * @returns Optional RequestPatch to merge into headers / override body.
-     * Returning a Response stops execution of the endpoint.
+     * @returns Optional Response to short-circuit the request.
      */
-    onRequest: async (ctx: { request: Request }): Promise<RequestPatch | Response | void> => {
+    onRequest: async (ctx: { request: Request }): Promise<Response | void> => {
       // Example Use Cases:
       // - Verify authentication
       // - Enforce rate limits

--- a/src/endpoints/chat-completions/handler.ts
+++ b/src/endpoints/chat-completions/handler.ts
@@ -29,7 +29,6 @@ import {
   recordTokenUsage,
 } from "../../telemetry/gen-ai";
 import { addSpanEvent, setSpanAttributes } from "../../telemetry/span";
-import { resolveRequestId } from "../../utils/headers";
 import { prepareForwardHeaders } from "../../utils/request";
 import { convertToTextCallOptions, toChatCompletions, toChatCompletionsStream } from "./converters";
 import {
@@ -51,8 +50,6 @@ export const chatCompletions = (config: GatewayConfig): Endpoint => {
     if (!ctx.request || ctx.request.method !== "POST") {
       throw new GatewayError("Method Not Allowed", 405);
     }
-
-    const requestId = resolveRequestId(ctx.request);
 
     // Parse + validate input.
     try {
@@ -107,7 +104,7 @@ export const chatCompletions = (config: GatewayConfig): Endpoint => {
     const textOptions = convertToTextCallOptions(inputs);
     logger.trace(
       {
-        requestId,
+        requestId: ctx.requestId,
         options: textOptions,
       },
       "[chat] AI SDK options",
@@ -178,7 +175,7 @@ export const chatCompletions = (config: GatewayConfig): Endpoint => {
       },
       ...textOptions,
     });
-    logger.trace({ requestId, result }, "[chat] AI SDK result");
+    logger.trace({ requestId: ctx.requestId, result }, "[chat] AI SDK result");
     addSpanEvent("hebo.ai-sdk.completed");
 
     // Transform result.

--- a/src/telemetry/http.ts
+++ b/src/telemetry/http.ts
@@ -1,5 +1,4 @@
 import { type TelemetrySignalLevel } from "../types";
-import { resolveRequestId } from "../utils/headers";
 
 const headerArr = (h: Headers, k: string) => (h.has(k) ? [h.get(k)!] : undefined);
 
@@ -29,8 +28,6 @@ export const getRequestAttributes = (request: Request, signalLevel?: TelemetrySi
 
   if (signalLevel !== "required") {
     Object.assign(attrs, {
-      // FUTURE: does ElysiaJS and other frameworks attach request id?
-      "http.request.id": resolveRequestId(request),
       "user_agent.original": request.headers.get("user-agent") ?? undefined,
     });
   }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,22 +1,13 @@
-import type { RequestPatch } from "../types";
-
 import pkg from "../../package.json" with { type: "json" };
-import { REQUEST_ID_HEADER } from "./headers";
+import { resolveRequestId } from "./headers";
 
 const GATEWAY_VERSION = pkg.version;
 
-export const prepareRequestHeaders = (request: Request) => {
-  const existingRequestId = request.headers.get(REQUEST_ID_HEADER);
-  if (existingRequestId) return;
+const createRequestId = () =>
+  "req_" + crypto.getRandomValues(new Uint32Array(2)).reduce((s, n) => s + n.toString(36), "");
 
-  const requestId =
-    "req_" + crypto.getRandomValues(new Uint32Array(2)).reduce((s, n) => s + n.toString(36), "");
-
-  const headers = new Headers(request.headers);
-  headers.set(REQUEST_ID_HEADER, requestId);
-
-  return headers;
-};
+export const resolveOrCreateRequestId = (request: Request) =>
+  resolveRequestId(request) ?? createRequestId();
 
 export const prepareForwardHeaders = (request: Request): Record<string, string> => {
   const userAgent = request.headers.get("user-agent");
@@ -27,23 +18,4 @@ export const prepareForwardHeaders = (request: Request): Record<string, string> 
   return {
     "user-agent": appendedUserAgent,
   };
-};
-
-export const maybeApplyRequestPatch = (request: Request, patch: RequestPatch) => {
-  if (!patch.headers && patch.body === undefined) return request;
-
-  if (!patch.headers) {
-    // eslint-disable-next-line no-invalid-fetch-options
-    return new Request(request, { body: patch.body });
-  }
-
-  const headers = new Headers(request.headers);
-  for (const [key, value] of new Headers(patch.headers)) {
-    headers.set(key, value);
-  }
-
-  const init: RequestInit = { headers };
-  if (patch.body !== undefined) init.body = patch.body;
-
-  return new Request(request, init);
 };

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,4 +1,4 @@
-import { REQUEST_ID_HEADER, resolveRequestId } from "./headers";
+import { REQUEST_ID_HEADER } from "./headers";
 
 const TEXT_ENCODER = new TextEncoder();
 
@@ -15,8 +15,8 @@ class JsonToSseTransformStream extends TransformStream<unknown, string> {
   }
 }
 
-export const prepareResponseInit = (request: Request): ResponseInit => ({
-  headers: { [REQUEST_ID_HEADER]: resolveRequestId(request)! },
+export const prepareResponseInit = (requestId: string): ResponseInit => ({
+  headers: { [REQUEST_ID_HEADER]: requestId },
 });
 
 export const mergeResponseInit = (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The onRequest hook signature has been updated to return only Response or void (removed RequestPatch support), eliminating request header patching capabilities.

* **Improvements**
  * Enhanced request identification and telemetry with improved request ID tracking and propagation throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->