### PR TITLE
feat(ci): integrate @claude commands

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,60 @@
+name: Claude Code
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened]
+
+jobs:
+  claude:
+    if: |
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        contains(github.event.issue.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          use_bedrock: "true"
+          claude_args: "--model us.anthropic.claude-opus-4-6-v1"


### PR DESCRIPTION
## Summary

- Add Claude Code GitHub Action workflow triggered by `@claude` mentions in issues and PR comments
- Uses AWS Bedrock (Opus 4.6) via OIDC for authentication -- no stored credentials
- Restricts runs to org members, owners, and collaborators via `author_association` check
- Add `.claude/CLAUDE.md` that imports existing `AGENTS.md` for project guidelines

## Prerequisites

- The GitHub App (Hebo Claude Assistant) must be installed on this repo
- Org-level secrets `APP_ID`, `APP_PRIVATE_KEY`, `AWS_ROLE_TO_ASSUME`, and `AWS_REGION` are already configured
- The IAM trust policy has been updated to allow `repo:8monkey-ai/hebo-gateway:*`

## Test plan

- [x] Verify the GitHub App is installed on this repo (Settings > GitHub Apps)
- [x] Merge and comment `@claude what files are in this repo?` on any issue or PR
- [ ] Confirm Claude responds and the Actions run succeeds

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude AI is now integrated into the repository to enhance code collaboration. Users can request code analysis and automated assistance by mentioning Claude in issues, pull requests, and code review comments.

* **Chores**
  * Added configuration and GitHub Actions automation workflow files for Claude integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->