### PR TITLE
ci(claude): expand allowed tools and increase max turns

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,4 +57,7 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_bedrock: "true"
-          claude_args: "--model us.anthropic.claude-opus-4-6-v1"
+          claude_args: |
+            --model us.anthropic.claude-opus-4-6-v1
+            --allowedTools Bash,Edit,Read,Write,Glob,Grep,LS,WebFetch,WebSearch
+            --max-turns 20


### PR DESCRIPTION
## Summary

- Allow Bash, Edit, Read, Write, Glob, Grep, LS, WebFetch, WebSearch tools for Claude
- Increase max-turns from 10 (default) to 20 for more complex tasks

Mirrors the same change in hebo-platform.

## Test plan

- [ ] Trigger `@claude` on an issue or PR and verify it can run bash commands without permission errors

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration parameters for Claude AI integration, including tool access restrictions and interaction limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->