### PR TITLE
ci(claude): increase max turns to 30

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,4 +61,4 @@ jobs:
           claude_args: |
             --model us.anthropic.claude-opus-4-6-v1
             --allowedTools Bash,Edit,Read,Write,Glob,Grep,LS,WebFetch,WebSearch
-            --max-turns 20
+            --max-turns 30


### PR DESCRIPTION
## Summary

- Increase `--max-turns` from 20 to 30 to allow Claude more iterations for complex tasks

Mirrors the same change in hebo-platform.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow automation parameters to enhance processing capacity in CI/CD pipeline operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->