### PR TITLE
ci(claude): increase max turns to 40

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,4 +61,4 @@ jobs:
           claude_args: |
             --model us.anthropic.claude-opus-4-6-v1
             --allowedTools Bash,Edit,Read,Write,Glob,Grep,LS,WebFetch,WebSearch
-            --max-turns 30
+            --max-turns 40


### PR DESCRIPTION
Increase `--max-turns` from 30 to 40. Mirrors hebo-platform.

Made with [Cursor](https://cursor.com)