### PR TITLE
feat(otel): add reasoning config attributes to chat request spans

### DIFF
--- a/src/endpoints/chat-completions/otel.test.ts
+++ b/src/endpoints/chat-completions/otel.test.ts
@@ -24,6 +24,33 @@ describe("Chat Completions OTEL", () => {
     expect(attrs["gen_ai.request.metadata.Org ID"]).toBe("o-123");
   });
 
+  test("should map reasoning config into request attributes", () => {
+    const inputs: ChatCompletionsBody = {
+      model: "openai/gpt-oss-20b",
+      messages: [{ role: "user", content: "hi" }],
+      reasoning: { enabled: true, effort: "high", max_tokens: 2048 },
+    };
+
+    const attrs = getChatRequestAttributes(inputs, "recommended");
+
+    expect(attrs["gen_ai.request.reasoning.enabled"]).toBe(true);
+    expect(attrs["gen_ai.request.reasoning.effort"]).toBe("high");
+    expect(attrs["gen_ai.request.reasoning.max_tokens"]).toBe(2048);
+  });
+
+  test("should omit reasoning attributes when reasoning config is absent", () => {
+    const inputs: ChatCompletionsBody = {
+      model: "openai/gpt-oss-20b",
+      messages: [{ role: "user", content: "hi" }],
+    };
+
+    const attrs = getChatRequestAttributes(inputs, "recommended");
+
+    expect(attrs["gen_ai.request.reasoning.enabled"]).toBeUndefined();
+    expect(attrs["gen_ai.request.reasoning.effort"]).toBeUndefined();
+    expect(attrs["gen_ai.request.reasoning.max_tokens"]).toBeUndefined();
+  });
+
   test("should stringify each tool definition individually", () => {
     const tool1 = {
       type: "function" as const,

--- a/src/endpoints/chat-completions/otel.ts
+++ b/src/endpoints/chat-completions/otel.ts
@@ -135,7 +135,9 @@ export const getChatRequestAttributes = (
 
   if (signalLevel !== "required") {
     Object.assign(attrs, {
-      // FUTURE: add reasoning info
+      "gen_ai.request.reasoning.enabled": body.reasoning?.enabled,
+      "gen_ai.request.reasoning.effort": body.reasoning?.effort,
+      "gen_ai.request.reasoning.max_tokens": body.reasoning?.max_tokens,
       "gen_ai.request.stream": body.stream,
       "gen_ai.request.service_tier": body.service_tier,
       "gen_ai.request.frequency_penalty": body.frequency_penalty,


### PR DESCRIPTION
Emit `gen_ai.request.reasoning.enabled`, `gen_ai.request.reasoning.effort`, and `gen_ai.request.reasoning.max_tokens` as OTel span attributes in `getChatRequestAttributes`.

Closes #84

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases to validate reasoning configuration telemetry mapping and attribute assignment.

* **Chores**
  * Enhanced request-level observability by adding telemetry attributes to monitor reasoning configuration status and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->