### PR TITLE
fix(google): reasoning effort "none" now uses thinkingBudget: 0 for Gemini 3

### DIFF
--- a/src/endpoints/shared/converters.test.ts
+++ b/src/endpoints/shared/converters.test.ts
@@ -71,14 +71,14 @@ describe("Shared Converters", () => {
   describe("parseReasoningOptions", () => {
     test("should return disabled when enabled is false", () => {
       expect(parseReasoningOptions(undefined, { enabled: false })).toEqual({
-        reasoning: { enabled: false },
+        reasoning: { enabled: false, effort: "none" },
         reasoning_effort: "none",
       });
     });
 
     test("should return disabled when effort is none", () => {
       expect(parseReasoningOptions("none")).toEqual({
-        reasoning: { enabled: false },
+        reasoning: { enabled: false, effort: "none" },
         reasoning_effort: "none",
       });
     });

--- a/src/endpoints/shared/converters.ts
+++ b/src/endpoints/shared/converters.ts
@@ -88,7 +88,7 @@ export function parseReasoningOptions(
   const max_tokens = reasoning?.max_tokens;
 
   if (reasoning?.enabled === false || effort === "none") {
-    return { reasoning: { enabled: false }, reasoning_effort: "none" };
+    return { reasoning: { enabled: false, effort: "none" }, reasoning_effort: "none" };
   }
   if (!reasoning && effort === undefined) return {};
 

--- a/src/models/google/middleware.test.ts
+++ b/src/models/google/middleware.test.ts
@@ -161,7 +161,7 @@ test("geminiReasoningMiddleware > should normalize none effort for Gemini 3.1 Fl
       google: {
         thinkingConfig: {
           includeThoughts: false,
-          thinkingLevel: "minimal",
+          thinkingBudget: 0,
         },
       },
       unknown: {},
@@ -221,7 +221,7 @@ test("geminiReasoningMiddleware > should handle disabled reasoning", async () =>
       google: {
         thinkingConfig: {
           includeThoughts: false,
-          thinkingLevel: "minimal",
+          thinkingBudget: 0,
         },
       },
       unknown: {},

--- a/src/models/google/middleware.ts
+++ b/src/models/google/middleware.ts
@@ -94,9 +94,14 @@ export const geminiReasoningMiddleware: LanguageModelMiddleware = {
           ),
       };
     } else if (modelId.includes("gemini-3") && reasoning.effort) {
-      target.thinkingConfig = {
-        thinkingLevel: mapGeminiReasoningEffort(reasoning.effort, modelId),
-      };
+      if (reasoning.effort === "none") {
+        // thinkingBudget: 0 fully disables thinking (thinkingLevel: "minimal" still allows some)
+        target.thinkingConfig = { thinkingBudget: 0 };
+      } else {
+        target.thinkingConfig = {
+          thinkingLevel: mapGeminiReasoningEffort(reasoning.effort, modelId),
+        };
+      }
       // FUTURE: warn if model is gemini-3 and max_tokens (unsupported) was ignored
     }
 


### PR DESCRIPTION
Fixes #97 — `reasoning.effort: "none"` and `reasoning.enabled: false` were not disabling thinking for Gemini 3 models.

## Summary

- `parseReasoningOptions` now preserves `effort: "none"` in the disabled case
- Gemini 3 middleware uses `thinkingBudget: 0` for `effort: "none"` (fully disables thinking)
- Other effort levels continue to use `thinkingLevel`

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced disabled reasoning state representation in API responses for improved consistency.
* Corrected Gemini model configuration to properly disable extended thinking when reasoning is disabled, ensuring more efficient processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->