### PR TITLE
feat: add gen_ai.request.service_tier to gen_ai metric attributes

### DIFF
--- a/src/endpoints/chat-completions/otel.ts
+++ b/src/endpoints/chat-completions/otel.ts
@@ -141,7 +141,6 @@ export const getChatRequestAttributes = (
       "gen_ai.request.reasoning.effort": body.reasoning?.effort,
       "gen_ai.request.reasoning.max_tokens": body.reasoning?.max_tokens,
       "gen_ai.request.stream": body.stream,
-      "gen_ai.request.service_tier": body.service_tier,
       "gen_ai.request.frequency_penalty": body.frequency_penalty,
       "gen_ai.request.max_tokens": body.max_completion_tokens,
       "gen_ai.request.presence_penalty": body.presence_penalty,

--- a/src/endpoints/responses/otel.test.ts
+++ b/src/endpoints/responses/otel.test.ts
@@ -152,7 +152,6 @@ describe("Responses OTEL", () => {
     expect(attrs["gen_ai.request.max_tokens"]).toBe(500);
     expect(attrs["gen_ai.request.frequency_penalty"]).toBe(0.5);
     expect(attrs["gen_ai.request.presence_penalty"]).toBe(-0.5);
-    expect(attrs["gen_ai.request.service_tier"]).toBe("priority");
   });
 
   test("should return empty for off signal level", () => {

--- a/src/endpoints/responses/otel.ts
+++ b/src/endpoints/responses/otel.ts
@@ -161,7 +161,6 @@ export const getResponsesRequestAttributes = (
   if (signalLevel !== "required") {
     Object.assign(attrs, {
       "gen_ai.request.stream": body.stream,
-      "gen_ai.request.service_tier": body.service_tier,
       "gen_ai.request.frequency_penalty": body.frequency_penalty,
       "gen_ai.request.max_tokens": body.max_output_tokens,
       "gen_ai.request.presence_penalty": body.presence_penalty,

--- a/src/telemetry/gen-ai.ts
+++ b/src/telemetry/gen-ai.ts
@@ -74,9 +74,15 @@ export const getGenAiGeneralAttributes = (
 
   const requestModel = typeof ctx.body?.model === "string" ? ctx.body.model : ctx.modelId;
 
+  const serviceTier =
+    ctx.body && "service_tier" in ctx.body
+      ? (ctx.body.service_tier as string | undefined)
+      : undefined;
+
   const attrs: Attributes = {
     "gen_ai.operation.name": ctx.operation,
     "gen_ai.request.model": requestModel,
+    "gen_ai.request.service_tier": serviceTier,
     "gen_ai.response.model": ctx.resolvedModelId,
     "gen_ai.provider.name": ctx.resolvedProviderId,
   };

--- a/src/telemetry/gen-ai.ts
+++ b/src/telemetry/gen-ai.ts
@@ -73,19 +73,19 @@ export const getGenAiGeneralAttributes = (
   if (!signalLevel || signalLevel === "off") return {};
 
   const requestModel = typeof ctx.body?.model === "string" ? ctx.body.model : ctx.modelId;
-
   const serviceTier =
-    ctx.body && "service_tier" in ctx.body
-      ? (ctx.body.service_tier as string | undefined)
-      : undefined;
+    typeof ctx.body?.service_tier === "string" ? ctx.body.service_tier : undefined;
 
   const attrs: Attributes = {
     "gen_ai.operation.name": ctx.operation,
     "gen_ai.request.model": requestModel,
-    "gen_ai.request.service_tier": serviceTier,
     "gen_ai.response.model": ctx.resolvedModelId,
     "gen_ai.provider.name": ctx.resolvedProviderId,
   };
+
+  if (signalLevel !== "required" && serviceTier !== undefined) {
+    attrs["gen_ai.request.service_tier"] = serviceTier;
+  }
 
   for (const [key, value] of Object.entries(ctx.otel)) {
     if (value !== undefined) attrs[key] = value;


### PR DESCRIPTION
Include `gen_ai.request.service_tier` in `getGenAiGeneralAttributes` so it propagates to `gen_ai.server.request.duration` and other metric histograms, not just span attributes. This enables the anomaly detection agent to group metrics by service tier and avoid false latency alerts from tier mixing.

Closes #109

Generated with [Claude Code](https://claude.ai/code)