### PR TITLE
feat(responses): preserve thinking block content and signature from Anthropic models

### DIFF
--- a/src/endpoints/responses/converters.test.ts
+++ b/src/endpoints/responses/converters.test.ts
@@ -22,7 +22,7 @@ import {
   type ResponsesStreamEvent,
   type ResponseOutputItemAddedEvent,
   type ResponseReasoningSummaryTextDeltaEvent,
-  type ResponseReasoningContentTextDeltaEvent,
+  type ResponseReasoningTextDeltaEvent,
   type ResponseOutputTextDeltaEvent,
   type ResponseCompletedEvent,
   type ResponseOutputItemDoneEvent,
@@ -798,23 +798,18 @@ describe("Responses Converters", () => {
 
       // Content deltas (parallel to summary)
       const contentDeltas = events.filter(
-        (e): e is ResponseReasoningContentTextDeltaEvent =>
-          e.event === "response.reasoning_content_text.delta",
+        (e): e is ResponseReasoningTextDeltaEvent =>
+          e.event === "response.reasoning_text.delta",
       );
       expect(contentDeltas).toHaveLength(2);
       expect(contentDeltas[0]!.data.delta).toBe("Let me");
       expect(contentDeltas[1]!.data.delta).toBe(" think...");
 
-      // Content part lifecycle events
-      const contentPartAdded = events.filter(
-        (e) => e.event === "response.reasoning_content_part.added",
+      // Content text done event
+      const contentTextDone = events.filter(
+        (e) => e.event === "response.reasoning_text.done",
       );
-      expect(contentPartAdded).toHaveLength(1);
-
-      const contentPartDone = events.filter(
-        (e) => e.event === "response.reasoning_content_part.done",
-      );
-      expect(contentPartDone).toHaveLength(1);
+      expect(contentTextDone).toHaveLength(1);
 
       // Text
       const textAdded = events.find(

--- a/src/endpoints/responses/converters.test.ts
+++ b/src/endpoints/responses/converters.test.ts
@@ -22,12 +22,14 @@ import {
   type ResponsesStreamEvent,
   type ResponseOutputItemAddedEvent,
   type ResponseReasoningSummaryTextDeltaEvent,
+  type ResponseReasoningContentTextDeltaEvent,
   type ResponseOutputTextDeltaEvent,
   type ResponseCompletedEvent,
   type ResponseOutputItemDoneEvent,
   type ResponsesOutputItem,
   type ResponsesFunctionCall,
   type ResponsesOutputMessage,
+  type ResponsesReasoningItem,
 } from "./schema";
 
 const mockUsage = (overrides: Partial<LanguageModelUsage> = {}): LanguageModelUsage =>
@@ -212,7 +214,7 @@ describe("Responses Converters", () => {
       });
     });
 
-    test("should convert reasoning items to assistant messages", () => {
+    test("should convert reasoning items to assistant messages from summary", () => {
       const messages = convertToModelMessages([
         {
           type: "reasoning",
@@ -226,6 +228,45 @@ describe("Responses Converters", () => {
         content: [{ type: "reasoning", text: "I'm thinking...", providerOptions: undefined }],
       });
       expect(messages[1]).toEqual({ role: "user", content: "Hi" });
+    });
+
+    test("should prefer content over summary in reasoning items", () => {
+      const messages = convertToModelMessages([
+        {
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "Short summary" }],
+          content: [{ type: "reasoning_text", text: "Full detailed thinking..." }],
+        },
+      ] satisfies ResponsesInputItem[]);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toEqual({
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "Full detailed thinking...", providerOptions: undefined },
+        ],
+      });
+    });
+
+    test("should pass signature through providerOptions on reasoning items", () => {
+      const messages = convertToModelMessages([
+        {
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "Thinking..." }],
+          content: [{ type: "reasoning_text", text: "Thinking..." }],
+          signature: "sig-abc123",
+        },
+      ] satisfies ResponsesInputItem[]);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toEqual({
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "Thinking...",
+            providerOptions: { unknown: { signature: "sig-abc123" } },
+          },
+        ],
+      });
     });
 
     test("should convert user message with input content parts", () => {
@@ -527,7 +568,7 @@ describe("Responses Converters", () => {
       }
     });
 
-    test("should include reasoning output items", () => {
+    test("should include reasoning output items with both summary and content", () => {
       const result = toResponses(
         mockGenerateTextResult({
           finishReason: "stop",
@@ -546,7 +587,36 @@ describe("Responses Converters", () => {
       expect(reasoning).toBeDefined();
       if (reasoning?.type === "reasoning") {
         expect(reasoning.summary[0]!.text).toBe("Let me think...");
+        expect(reasoning.content).toBeDefined();
+        expect(reasoning.content![0]!.type).toBe("reasoning_text");
+        expect(reasoning.content![0]!.text).toBe("Let me think...");
       }
+    });
+
+    test("should surface signature on reasoning output items", () => {
+      const result = toResponses(
+        mockGenerateTextResult({
+          finishReason: "stop",
+          text: "42",
+          content: [
+            {
+              type: "reasoning",
+              text: "Thinking...",
+              providerMetadata: { anthropic: { signature: "sig-abc123" } },
+            },
+            { type: "text", text: "42" },
+          ],
+          usage: mockUsage({ inputTokens: 10, outputTokens: 5, totalTokens: 15 }),
+          totalUsage: mockUsage({ inputTokens: 10, outputTokens: 5, totalTokens: 15 }),
+        }),
+        "anthropic/claude-4-opus",
+      );
+
+      const reasoning = result.output.find(
+        (o): o is ResponsesReasoningItem => o.type === "reasoning",
+      );
+      expect(reasoning).toBeDefined();
+      expect(reasoning!.signature).toBe("sig-abc123");
     });
 
     test("should set incomplete status for length finish reason", () => {
@@ -726,6 +796,26 @@ describe("Responses Converters", () => {
       expect(reasoningDeltas[0]!.data.delta).toBe("Let me");
       expect(reasoningDeltas[1]!.data.delta).toBe(" think...");
 
+      // Content deltas (parallel to summary)
+      const contentDeltas = events.filter(
+        (e): e is ResponseReasoningContentTextDeltaEvent =>
+          e.event === "response.reasoning_content_text.delta",
+      );
+      expect(contentDeltas).toHaveLength(2);
+      expect(contentDeltas[0]!.data.delta).toBe("Let me");
+      expect(contentDeltas[1]!.data.delta).toBe(" think...");
+
+      // Content part lifecycle events
+      const contentPartAdded = events.filter(
+        (e) => e.event === "response.reasoning_content_part.added",
+      );
+      expect(contentPartAdded).toHaveLength(1);
+
+      const contentPartDone = events.filter(
+        (e) => e.event === "response.reasoning_content_part.done",
+      );
+      expect(contentPartDone).toHaveLength(1);
+
       // Text
       const textAdded = events.find(
         (e): e is ResponseOutputItemAddedEvent =>
@@ -748,10 +838,60 @@ describe("Responses Converters", () => {
       expect(completedResponse.status).toBe("completed");
       expect(completedResponse.output).toHaveLength(2);
       expect(completedResponse.output[0]!.type).toBe("reasoning");
+      const completedReasoning = completedResponse.output[0] as ResponsesReasoningItem;
+      expect(completedReasoning.summary[0]!.text).toBe("Let me think...");
+      expect(completedReasoning.content).toBeDefined();
+      expect(completedReasoning.content![0]!.text).toBe("Let me think...");
       expect(completedResponse.output[1]!.type).toBe("message");
       expect((completedResponse.output[1] as ResponsesOutputMessage).content[0]!.text).toBe(
         "Hello",
       );
+    });
+
+    test("should surface signature on streamed reasoning items", async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            type: "reasoning-start",
+            id: "r1",
+            providerMetadata: { anthropic: { signature: "sig-stream123" } },
+          });
+          controller.enqueue({ type: "reasoning-delta", text: "Thinking" });
+          controller.enqueue({ type: "reasoning-end", id: "r1" });
+          controller.enqueue({
+            type: "finish",
+            finishReason: "stop",
+            totalUsage: mockUsage({ inputTokens: 5, outputTokens: 5, totalTokens: 10 }),
+          });
+          controller.close();
+        },
+      });
+
+      const transformed = stream.pipeThrough(new ResponsesTransformStream("anthropic/claude-4"));
+      const reader = transformed.getReader();
+      const events: ResponsesStreamEvent[] = [];
+
+      while (true) {
+        // oxlint-disable-next-line no-await-in-loop
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value && "event" in (value as object)) {
+          events.push(value as ResponsesStreamEvent);
+        }
+      }
+
+      const reasoningAdded = events.find(
+        (e): e is ResponseOutputItemAddedEvent =>
+          e.event === "response.output_item.added" && e.data.item.type === "reasoning",
+      );
+      expect(reasoningAdded).toBeDefined();
+      expect((reasoningAdded!.data.item as ResponsesReasoningItem).signature).toBe("sig-stream123");
+
+      const completed = events.find(
+        (e): e is ResponseCompletedEvent => e.event === "response.completed",
+      );
+      const completedReasoning = completed!.data.response.output[0] as ResponsesReasoningItem;
+      expect(completedReasoning.signature).toBe("sig-stream123");
     });
 
     test("should carry final tool-call metadata onto the streamed item when inProgress", async () => {

--- a/src/endpoints/responses/converters.ts
+++ b/src/endpoints/responses/converters.ts
@@ -905,13 +905,13 @@ export class ResponsesTransformStream extends TransformStream<
         const lastContentPart = reasoningItem.content[reasoningContentIndex];
         if (lastContentPart) {
           controller.enqueue({
-            event: "response.reasoning_content_part.done",
+            event: "response.reasoning_text.done",
             data: {
-              type: "response.reasoning_content_part.done",
+              type: "response.reasoning_text.done",
               item_id: reasoningItem.id!,
               output_index: reasoningOutputIndex,
               content_index: reasoningContentIndex,
-              part: lastContentPart,
+              text: lastContentPart.text,
             },
           });
         }
@@ -1163,28 +1163,14 @@ export class ResponsesTransformStream extends TransformStream<
                 text: "",
               };
               contentArr.push(contentPart);
-
-              controller.enqueue({
-                event: "response.reasoning_content_part.added",
-                data: {
-                  type: "response.reasoning_content_part.added",
-                  item_id: reasoningItem!.id!,
-                  output_index: reasoningOutputIndex,
-                  content_index: reasoningContentIndex,
-                  part: {
-                    type: "reasoning_text",
-                    text: "",
-                  },
-                },
-              });
             }
 
             contentArr[reasoningContentIndex]!.text += part.text;
 
             controller.enqueue({
-              event: "response.reasoning_content_text.delta",
+              event: "response.reasoning_text.delta",
               data: {
-                type: "response.reasoning_content_text.delta",
+                type: "response.reasoning_text.delta",
                 item_id: reasoningItem!.id!,
                 output_index: reasoningOutputIndex,
                 content_index: reasoningContentIndex,

--- a/src/endpoints/responses/converters.ts
+++ b/src/endpoints/responses/converters.ts
@@ -59,6 +59,7 @@ import type {
   ResponsesTool,
   ResponsesTextConfig,
   ResponsesSummaryText,
+  ResponsesReasoningText,
 } from "./schema";
 
 // --- Helpers ---
@@ -187,19 +188,27 @@ export function convertToModelMessages(
 function fromReasoningItem(item: ResponsesReasoningItem): AssistantModelMessage {
   const parts: AssistantContent = [];
 
-  if (!item.summary || item.summary.length === 0) {
+  // Prefer content (full thinking text) over summary when available
+  const source = item.content && item.content.length > 0 ? item.content : item.summary;
+
+  if (!source || source.length === 0) {
     return { role: "assistant", content: parts };
   }
 
   let providerOptions: SharedV3ProviderOptions | undefined;
-  if (item.extra_content || item.encrypted_content) {
-    providerOptions = item.extra_content ?? { unknown: {} };
+  if (item.extra_content || item.encrypted_content || item.signature) {
+    providerOptions = item.extra_content ? { ...item.extra_content } : { unknown: {} };
+    const existing = (providerOptions["unknown"] ?? {}) as Record<string, string>;
     if (item.encrypted_content) {
-      (providerOptions ??= {})["unknown"] = { redactedData: item.encrypted_content };
+      existing["redactedData"] = item.encrypted_content;
     }
+    if (item.signature) {
+      existing["signature"] = item.signature;
+    }
+    providerOptions["unknown"] = existing;
   }
 
-  for (const s of item.summary) {
+  for (const s of source) {
     parts.push({
       type: "reasoning",
       text: s.text,
@@ -648,14 +657,18 @@ function toReasoningOutputItem(reasoning: ReasoningOutput): ResponsesReasoningIt
 
   if (reasoning.text) {
     item.summary = [{ type: "summary_text", text: reasoning.text }];
+    item.content = [{ type: "reasoning_text", text: reasoning.text }];
   }
 
   const providerMetadata = reasoning.providerMetadata ?? {};
   item.extra_content = providerMetadata;
 
-  const { redactedData } = extractReasoningMetadata(providerMetadata);
+  const { redactedData, signature } = extractReasoningMetadata(providerMetadata);
   if (redactedData) {
     item.encrypted_content = redactedData;
+  }
+  if (signature) {
+    item.signature = signature;
   }
 
   return item;
@@ -756,6 +769,7 @@ export class ResponsesTransformStream extends TransformStream<
     let reasoningItem: ResponsesReasoningItem | undefined;
     let reasoningOutputIndex = -1;
     let summaryIndex = 0;
+    let reasoningContentIndex = 0;
     let finishProviderMetadata: SharedV3ProviderMetadata | undefined;
     const outputItems: ResponsesOutputItem[] = [];
     const inProgressToolCalls = new Map<
@@ -796,11 +810,16 @@ export class ResponsesTransformStream extends TransformStream<
             id: item.id,
             status: item.status,
             summary: item.summary.map((s) => ({
-              type: "summary_text",
+              type: "summary_text" as const,
               text: s.text,
+            })),
+            content: item.content?.map((c) => ({
+              type: "reasoning_text" as const,
+              text: c.text,
             })),
             extra_content: item.extra_content,
             encrypted_content: item.encrypted_content,
+            signature: item.signature,
           };
         }
         if (item.type === "function_call") {
@@ -877,6 +896,22 @@ export class ResponsesTransformStream extends TransformStream<
               output_index: reasoningOutputIndex,
               summary_index: summaryIndex,
               part: lastSummaryPart,
+            },
+          });
+        }
+      }
+
+      if (reasoningItem && reasoningItem.content && reasoningItem.content.length > 0) {
+        const lastContentPart = reasoningItem.content[reasoningContentIndex];
+        if (lastContentPart) {
+          controller.enqueue({
+            event: "response.reasoning_content_part.done",
+            data: {
+              type: "response.reasoning_content_part.done",
+              item_id: reasoningItem.id!,
+              output_index: reasoningOutputIndex,
+              content_index: reasoningContentIndex,
+              part: lastContentPart,
             },
           });
         }
@@ -1044,18 +1079,23 @@ export class ResponsesTransformStream extends TransformStream<
               id: uuidv7(),
               status: "in_progress",
               summary: [],
+              content: [],
             };
 
             const providerMetadata = part.providerMetadata;
             if (providerMetadata) {
               reasoningItem.extra_content = providerMetadata;
-              const { redactedData } = extractReasoningMetadata(providerMetadata);
+              const { redactedData, signature } = extractReasoningMetadata(providerMetadata);
               if (redactedData) {
                 reasoningItem.encrypted_content = redactedData;
+              }
+              if (signature) {
+                reasoningItem.signature = signature;
               }
             }
 
             reasoningOutputIndex = outputIndex++;
+            reasoningContentIndex = 0;
             outputItems.push(reasoningItem);
 
             controller.enqueue({
@@ -1068,8 +1108,10 @@ export class ResponsesTransformStream extends TransformStream<
                   id: reasoningItem.id,
                   status: "in_progress",
                   summary: [],
+                  content: [],
                   extra_content: reasoningItem.extra_content,
                   encrypted_content: reasoningItem.encrypted_content,
+                  signature: reasoningItem.signature,
                 },
               },
             });
@@ -1077,6 +1119,7 @@ export class ResponsesTransformStream extends TransformStream<
           }
 
           case "reasoning-delta": {
+            // Summary deltas
             if (summaryIndex === reasoningItem!.summary.length) {
               const summaryPart: ResponsesSummaryText = {
                 type: "summary_text",
@@ -1108,6 +1151,43 @@ export class ResponsesTransformStream extends TransformStream<
                 item_id: reasoningItem!.id!,
                 output_index: reasoningOutputIndex,
                 summary_index: summaryIndex,
+                delta: part.text,
+              },
+            });
+
+            // Content deltas (parallel to summary)
+            const contentArr = reasoningItem!.content!;
+            if (reasoningContentIndex === contentArr.length) {
+              const contentPart: ResponsesReasoningText = {
+                type: "reasoning_text",
+                text: "",
+              };
+              contentArr.push(contentPart);
+
+              controller.enqueue({
+                event: "response.reasoning_content_part.added",
+                data: {
+                  type: "response.reasoning_content_part.added",
+                  item_id: reasoningItem!.id!,
+                  output_index: reasoningOutputIndex,
+                  content_index: reasoningContentIndex,
+                  part: {
+                    type: "reasoning_text",
+                    text: "",
+                  },
+                },
+              });
+            }
+
+            contentArr[reasoningContentIndex]!.text += part.text;
+
+            controller.enqueue({
+              event: "response.reasoning_content_text.delta",
+              data: {
+                type: "response.reasoning_content_text.delta",
+                item_id: reasoningItem!.id!,
+                output_index: reasoningOutputIndex,
+                content_index: reasoningContentIndex,
                 delta: part.text,
               },
             });

--- a/src/endpoints/responses/schema.ts
+++ b/src/endpoints/responses/schema.ts
@@ -513,37 +513,26 @@ export type ResponseReasoningSummaryPartDoneEvent = SseFrame<
   "response.reasoning_summary_part.done"
 >;
 
-export type ResponseReasoningContentPartAddedEvent = SseFrame<
+export type ResponseReasoningTextDeltaEvent = SseFrame<
   {
-    type: "response.reasoning_content_part.added";
-    item_id: string;
-    output_index: number;
-    content_index: number;
-    part: ResponsesReasoningText;
-  },
-  "response.reasoning_content_part.added"
->;
-
-export type ResponseReasoningContentTextDeltaEvent = SseFrame<
-  {
-    type: "response.reasoning_content_text.delta";
+    type: "response.reasoning_text.delta";
     item_id: string;
     output_index: number;
     content_index: number;
     delta: string;
   },
-  "response.reasoning_content_text.delta"
+  "response.reasoning_text.delta"
 >;
 
-export type ResponseReasoningContentPartDoneEvent = SseFrame<
+export type ResponseReasoningTextDoneEvent = SseFrame<
   {
-    type: "response.reasoning_content_part.done";
+    type: "response.reasoning_text.done";
     item_id: string;
     output_index: number;
     content_index: number;
-    part: ResponsesReasoningText;
+    text: string;
   },
-  "response.reasoning_content_part.done"
+  "response.reasoning_text.done"
 >;
 
 export type ResponseOutputItemDoneEvent = SseFrame<
@@ -593,13 +582,12 @@ export type ResponsesStreamEvent =
   | ResponseOutputItemAddedEvent
   | ResponseContentPartAddedEvent
   | ResponseReasoningSummaryPartAddedEvent
-  | ResponseReasoningContentPartAddedEvent
   | ResponseOutputTextDeltaEvent
   | ResponseReasoningSummaryTextDeltaEvent
-  | ResponseReasoningContentTextDeltaEvent
+  | ResponseReasoningTextDeltaEvent
   | ResponseContentPartDoneEvent
   | ResponseReasoningSummaryPartDoneEvent
-  | ResponseReasoningContentPartDoneEvent
+  | ResponseReasoningTextDoneEvent
   | ResponseOutputItemDoneEvent
   | ResponseFunctionCallArgumentsDeltaEvent
   | ResponseFunctionCallArgumentsDoneEvent

--- a/src/endpoints/responses/schema.ts
+++ b/src/endpoints/responses/schema.ts
@@ -191,6 +191,8 @@ export const ResponsesReasoningItemSchema = z.object({
   status: ResponsesItemStatusSchema.optional(),
   // Extension origin: Gemini
   extra_content: ResponsesProviderMetadataSchema.optional().meta({ extension: true }),
+  // Extension origin: Anthropic/OpenRouter
+  signature: z.string().optional().meta({ extension: true }),
 });
 export type ResponsesReasoningItem = z.infer<typeof ResponsesReasoningItemSchema>;
 
@@ -511,6 +513,39 @@ export type ResponseReasoningSummaryPartDoneEvent = SseFrame<
   "response.reasoning_summary_part.done"
 >;
 
+export type ResponseReasoningContentPartAddedEvent = SseFrame<
+  {
+    type: "response.reasoning_content_part.added";
+    item_id: string;
+    output_index: number;
+    content_index: number;
+    part: ResponsesReasoningText;
+  },
+  "response.reasoning_content_part.added"
+>;
+
+export type ResponseReasoningContentTextDeltaEvent = SseFrame<
+  {
+    type: "response.reasoning_content_text.delta";
+    item_id: string;
+    output_index: number;
+    content_index: number;
+    delta: string;
+  },
+  "response.reasoning_content_text.delta"
+>;
+
+export type ResponseReasoningContentPartDoneEvent = SseFrame<
+  {
+    type: "response.reasoning_content_part.done";
+    item_id: string;
+    output_index: number;
+    content_index: number;
+    part: ResponsesReasoningText;
+  },
+  "response.reasoning_content_part.done"
+>;
+
 export type ResponseOutputItemDoneEvent = SseFrame<
   {
     type: "response.output_item.done";
@@ -558,10 +593,13 @@ export type ResponsesStreamEvent =
   | ResponseOutputItemAddedEvent
   | ResponseContentPartAddedEvent
   | ResponseReasoningSummaryPartAddedEvent
+  | ResponseReasoningContentPartAddedEvent
   | ResponseOutputTextDeltaEvent
   | ResponseReasoningSummaryTextDeltaEvent
+  | ResponseReasoningContentTextDeltaEvent
   | ResponseContentPartDoneEvent
   | ResponseReasoningSummaryPartDoneEvent
+  | ResponseReasoningContentPartDoneEvent
   | ResponseOutputItemDoneEvent
   | ResponseFunctionCallArgumentsDeltaEvent
   | ResponseFunctionCallArgumentsDoneEvent


### PR DESCRIPTION
Closes #111

Populate the `content` field (reasoning_text items) alongside `summary` on reasoning output items, surface `signature` as a first-class extension field, stream reasoning content deltas in parallel with summary deltas, and read `content`/`signature` back in the input path so multi-turn conversations preserve the full thinking chain.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added signature metadata support for reasoning items
  * Added streaming events for reasoning text parts and deltas to surface incremental content and signatures

* **Bug Fixes**
  * Prioritize reasoning content over summary when both are present
  * Ensure streamed and final reasoning outputs include content and propagated signature metadata

* **Tests**
  * Added/updated tests covering content vs. summary handling, signature propagation, and streaming reasoning events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->