### PR TITLE
feat: add per-request trace control via ctx.trace and body parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,6 +926,42 @@ These attributes appear on the active span and on all metric instruments (reques
 > To populate custom span attributes, the inbound W3C `baggage` header is supported. Keys in the `hebo.` namespace are mapped to span attributes, with the namespace stripped. For example: `baggage: hebo.user_id=u-123` becomes span attribute `user_id=u-123`.  
 > For `/chat/completions` and `/embeddings`, request `metadata` (`Record<string, string>`, key 1-64 chars, value up to 512 chars) is also forwarded to spans as `gen_ai.request.metadata.<key>`.
 
+#### Per-Request Trace Control
+
+You can override the global `telemetry.signals.gen_ai` level on a per-request basis using the `trace` body parameter. This is useful for selectively enabling detailed traces on specific requests without changing the gateway-wide configuration.
+
+The `trace` parameter is accepted on all endpoints (`/chat/completions`, `/embeddings`, `/messages`, `/responses`):
+
+```json
+{
+  "model": "openai/gpt-oss-20b",
+  "messages": [{ "role": "user", "content": "Hello" }],
+  "trace": "full"
+}
+```
+
+Accepted values:
+
+- `false` — disables tracing for this request (equivalent to `"off"`)
+- `true` — uses the global default (same as omitting the parameter)
+- `"off"` | `"required"` | `"recommended"` | `"full"` — sets the signal level for this request
+
+The resolution order is: **hook-set `ctx.trace`** > **body `trace` parameter** > **`cfg.telemetry.signals.gen_ai`**. This means hooks can always override the body parameter by setting `ctx.trace` directly:
+
+```ts
+hooks: {
+  before: (ctx) => {
+    // Force full tracing for a specific user
+    if (ctx.state.userId === "debug-user") {
+      ctx.trace = "full";
+    }
+  },
+}
+```
+
+> [!NOTE]
+> The `trace` parameter only affects span attributes and metrics signal level — it does not control whether tracing is enabled globally. The `telemetry.enabled` config field must still be `true` for any telemetry to be emitted.
+
 #### Metrics
 
 The Gateway also emits `gen_ai` metrics:

--- a/src/endpoints/chat-completions/handler.ts
+++ b/src/endpoints/chat-completions/handler.ts
@@ -95,12 +95,12 @@ export const chatCompletions = (config: GatewayConfig): Endpoint => {
     logger.debug(`[chat] using ${languageModel.provider} for ${ctx.resolvedModelId}`);
     addSpanEvent("hebo.provider.resolved");
 
-    const genAiSignalLevel = cfg.telemetry?.signals?.gen_ai;
-    const genAiGeneralAttrs = getGenAiGeneralAttributes(ctx, genAiSignalLevel);
+    ctx.trace ??= ctx.body.trace ?? cfg.telemetry?.signals?.gen_ai;
+    const genAiGeneralAttrs = getGenAiGeneralAttributes(ctx, ctx.trace);
     setSpanAttributes(genAiGeneralAttrs);
 
     // Convert inputs to AI SDK call options.
-    const { model: _model, stream, ...inputs } = ctx.body;
+    const { model: _model, stream, trace: _trace, ...inputs } = ctx.body;
     const textOptions = convertToTextCallOptions(inputs as ChatCompletionsInputs);
     logger.trace(
       {
@@ -110,7 +110,7 @@ export const chatCompletions = (config: GatewayConfig): Endpoint => {
       "[chat] AI SDK options",
     );
     addSpanEvent("hebo.options.prepared");
-    setSpanAttributes(getChatRequestAttributes(ctx.body, genAiSignalLevel));
+    setSpanAttributes(getChatRequestAttributes(ctx.body, ctx.trace));
 
     // Build middleware chain (model -> forward params -> provider).
     const languageModelWithMiddleware = wrapLanguageModel({
@@ -136,7 +136,7 @@ export const chatCompletions = (config: GatewayConfig): Endpoint => {
         onChunk: () => {
           if (!ttft) {
             ttft = performance.now() - start;
-            recordTimeToFirstToken(ttft, genAiGeneralAttrs, genAiSignalLevel);
+            recordTimeToFirstToken(ttft, genAiGeneralAttrs, ctx.trace);
           }
         },
         onFinish: (res) => {
@@ -151,16 +151,10 @@ export const chatCompletions = (config: GatewayConfig): Endpoint => {
           );
           addSpanEvent("hebo.result.transformed");
 
-          const genAiResponseAttrs = getChatResponseAttributes(streamResult, genAiSignalLevel);
+          const genAiResponseAttrs = getChatResponseAttributes(streamResult, ctx.trace);
           setSpanAttributes(genAiResponseAttrs);
-          recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, genAiSignalLevel);
-          recordTimePerOutputToken(
-            start,
-            ttft,
-            genAiResponseAttrs,
-            genAiGeneralAttrs,
-            genAiSignalLevel,
-          );
+          recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
+          recordTimePerOutputToken(start, ttft, genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
         },
         experimental_include: {
           requestBody: false,
@@ -193,23 +187,23 @@ export const chatCompletions = (config: GatewayConfig): Endpoint => {
     });
     logger.trace({ requestId: ctx.requestId, result }, "[chat] AI SDK result");
     addSpanEvent("hebo.ai-sdk.completed");
-    recordTimeToFirstToken(performance.now() - start, genAiGeneralAttrs, genAiSignalLevel);
+    recordTimeToFirstToken(performance.now() - start, genAiGeneralAttrs, ctx.trace);
 
     // Transform result.
     ctx.result = toChatCompletions(result, ctx.resolvedModelId);
     logger.trace({ requestId: ctx.requestId, result: ctx.result }, "[chat] ChatCompletions");
     addSpanEvent("hebo.result.transformed");
 
-    const genAiResponseAttrs = getChatResponseAttributes(ctx.result, genAiSignalLevel);
+    const genAiResponseAttrs = getChatResponseAttributes(ctx.result, ctx.trace);
     setSpanAttributes(genAiResponseAttrs);
-    recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, genAiSignalLevel);
+    recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
 
     if (hooks?.after) {
       ctx.result = (await hooks.after(ctx as AfterHookContext)) ?? ctx.result;
       addSpanEvent("hebo.hooks.after.completed");
     }
 
-    recordTimePerOutputToken(start, 0, genAiResponseAttrs, genAiGeneralAttrs, genAiSignalLevel);
+    recordTimePerOutputToken(start, 0, genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
     return ctx.result;
   };
 

--- a/src/endpoints/chat-completions/schema.ts
+++ b/src/endpoints/chat-completions/schema.ts
@@ -14,6 +14,7 @@ import {
   type ProviderMetadata as ChatCompletionsProviderMetadata,
   ContentPartAudioSchema as ChatCompletionsContentPartAudioSchema,
   type ContentPartAudio as ChatCompletionsContentPartAudio,
+  TraceSchema,
 } from "../shared/schema";
 
 export {
@@ -248,6 +249,7 @@ export type ChatCompletionsInputs = z.infer<typeof ChatCompletionsInputsSchema>;
 export const ChatCompletionsBodySchema = z.looseObject({
   model: z.string(),
   stream: z.boolean().optional(),
+  trace: TraceSchema,
   ...ChatCompletionsInputsSchema.shape,
 });
 export type ChatCompletionsBody = z.infer<typeof ChatCompletionsBodySchema>;

--- a/src/endpoints/embeddings/handler.ts
+++ b/src/endpoints/embeddings/handler.ts
@@ -82,19 +82,19 @@ export const embeddings = (config: GatewayConfig): Endpoint => {
     logger.debug(`[embeddings] using ${embeddingModel.provider} for ${ctx.resolvedModelId}`);
     addSpanEvent("hebo.provider.resolved");
 
-    const genAiSignalLevel = cfg.telemetry?.signals?.gen_ai;
-    const genAiGeneralAttrs = getGenAiGeneralAttributes(ctx, genAiSignalLevel);
+    ctx.trace ??= ctx.body.trace ?? cfg.telemetry?.signals?.gen_ai;
+    const genAiGeneralAttrs = getGenAiGeneralAttributes(ctx, ctx.trace);
     setSpanAttributes(genAiGeneralAttrs);
 
     // Convert inputs to AI SDK call options.
-    const { model: _model, ...inputs } = ctx.body;
+    const { model: _model, trace: _trace, ...inputs } = ctx.body;
     const embedOptions = convertToEmbedCallOptions(inputs as EmbeddingsInputs);
     logger.trace(
       { requestId: ctx.requestId, options: embedOptions },
       "[embeddings] AI SDK options",
     );
     addSpanEvent("hebo.options.prepared");
-    setSpanAttributes(getEmbeddingsRequestAttributes(ctx.body, genAiSignalLevel));
+    setSpanAttributes(getEmbeddingsRequestAttributes(ctx.body, ctx.trace));
 
     // Build middleware chain (model -> forward params -> provider).
     const embeddingModelWithMiddleware = wrapEmbeddingModel({
@@ -117,8 +117,8 @@ export const embeddings = (config: GatewayConfig): Endpoint => {
     ctx.result = toEmbeddings(result, ctx.modelId);
     logger.trace({ requestId: ctx.requestId, result: ctx.result }, "[chat] Embeddings");
     addSpanEvent("hebo.result.transformed");
-    const genAiResponseAttrs = getEmbeddingsResponseAttributes(ctx.result, genAiSignalLevel);
-    recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, genAiSignalLevel);
+    const genAiResponseAttrs = getEmbeddingsResponseAttributes(ctx.result, ctx.trace);
+    recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
     setSpanAttributes(genAiResponseAttrs);
 
     if (hooks?.after) {
@@ -126,7 +126,7 @@ export const embeddings = (config: GatewayConfig): Endpoint => {
       addSpanEvent("hebo.hooks.after.completed");
     }
 
-    recordTimePerOutputToken(start, 0, genAiResponseAttrs, genAiGeneralAttrs, genAiSignalLevel);
+    recordTimePerOutputToken(start, 0, genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
     return ctx.result;
   };
 

--- a/src/endpoints/embeddings/schema.ts
+++ b/src/endpoints/embeddings/schema.ts
@@ -1,5 +1,7 @@
 import * as z from "zod";
 
+import { TraceSchema } from "../shared/schema";
+
 export const EmbeddingsDimensionsSchema = z.int().nonnegative().max(65536);
 export type EmbeddingsDimensions = z.infer<typeof EmbeddingsDimensionsSchema>;
 
@@ -15,6 +17,7 @@ export type EmbeddingsInputs = z.infer<typeof EmbeddingsInputsSchema>;
 
 export const EmbeddingsBodySchema = z.looseObject({
   model: z.string(),
+  trace: TraceSchema,
   ...EmbeddingsInputsSchema.shape,
 });
 export type EmbeddingsBody = z.infer<typeof EmbeddingsBodySchema>;

--- a/src/endpoints/messages/handler.ts
+++ b/src/endpoints/messages/handler.ts
@@ -88,15 +88,15 @@ export const messages = (config: GatewayConfig): Endpoint => {
     logger.debug(`[messages] using ${languageModel.provider} for ${ctx.resolvedModelId}`);
     addSpanEvent("hebo.provider.resolved");
 
-    const genAiSignalLevel = cfg.telemetry?.signals?.gen_ai;
-    const genAiGeneralAttrs = getGenAiGeneralAttributes(ctx, genAiSignalLevel);
+    ctx.trace ??= ctx.body.trace ?? cfg.telemetry?.signals?.gen_ai;
+    const genAiGeneralAttrs = getGenAiGeneralAttributes(ctx, ctx.trace);
     setSpanAttributes(genAiGeneralAttrs);
 
-    const { model: _model, stream, ...inputs } = ctx.body;
+    const { model: _model, stream, trace: _trace, ...inputs } = ctx.body;
     const textOptions = convertToTextCallOptions(inputs as MessagesInputs);
     logger.trace({ requestId: ctx.requestId, options: textOptions }, "[messages] AI SDK options");
     addSpanEvent("hebo.options.prepared");
-    setSpanAttributes(getMessagesRequestAttributes(ctx.body, genAiSignalLevel));
+    setSpanAttributes(getMessagesRequestAttributes(ctx.body, ctx.trace));
 
     const languageModelWithMiddleware = wrapLanguageModel({
       model: languageModel,
@@ -120,7 +120,7 @@ export const messages = (config: GatewayConfig): Endpoint => {
         onChunk: () => {
           if (!ttft) {
             ttft = performance.now() - start;
-            recordTimeToFirstToken(ttft, genAiGeneralAttrs, genAiSignalLevel);
+            recordTimeToFirstToken(ttft, genAiGeneralAttrs, ctx.trace);
           }
         },
         onFinish: (res) => {
@@ -134,18 +134,12 @@ export const messages = (config: GatewayConfig): Endpoint => {
 
           const genAiResponseAttrs = getMessagesResponseAttributes(
             streamResult,
-            genAiSignalLevel,
+            ctx.trace,
             res.finishReason,
           );
           setSpanAttributes(genAiResponseAttrs);
-          recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, genAiSignalLevel);
-          recordTimePerOutputToken(
-            start,
-            ttft,
-            genAiResponseAttrs,
-            genAiGeneralAttrs,
-            genAiSignalLevel,
-          );
+          recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
+          recordTimePerOutputToken(start, ttft, genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
         },
         experimental_include: {
           requestBody: false,
@@ -178,7 +172,7 @@ export const messages = (config: GatewayConfig): Endpoint => {
     });
     logger.trace({ requestId: ctx.requestId, result }, "[messages] AI SDK result");
     addSpanEvent("hebo.ai-sdk.completed");
-    recordTimeToFirstToken(performance.now() - start, genAiGeneralAttrs, genAiSignalLevel);
+    recordTimeToFirstToken(performance.now() - start, genAiGeneralAttrs, ctx.trace);
 
     ctx.result = toMessages(result, ctx.resolvedModelId);
     logger.trace({ requestId: ctx.requestId, result: ctx.result }, "[messages] Messages");
@@ -186,18 +180,18 @@ export const messages = (config: GatewayConfig): Endpoint => {
 
     const genAiResponseAttrs = getMessagesResponseAttributes(
       ctx.result,
-      genAiSignalLevel,
+      ctx.trace,
       result.finishReason,
     );
     setSpanAttributes(genAiResponseAttrs);
-    recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, genAiSignalLevel);
+    recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
 
     if (hooks?.after) {
       ctx.result = (await hooks.after(ctx as AfterHookContext)) ?? ctx.result;
       addSpanEvent("hebo.hooks.after.completed");
     }
 
-    recordTimePerOutputToken(start, 0, genAiResponseAttrs, genAiGeneralAttrs, genAiSignalLevel);
+    recordTimePerOutputToken(start, 0, genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
     return ctx.result;
   };
 

--- a/src/endpoints/messages/schema.ts
+++ b/src/endpoints/messages/schema.ts
@@ -1,7 +1,7 @@
 import * as z from "zod";
 
 import type { SseFrame } from "../../utils/stream";
-import { CacheControlSchema, ProviderMetadataSchema } from "../shared/schema";
+import { CacheControlSchema, ProviderMetadataSchema, TraceSchema } from "../shared/schema";
 import type { ProviderMetadata } from "../shared/schema";
 
 // --- Content Block Schemas ---
@@ -220,6 +220,7 @@ export const MessagesBodySchema = z.object({
   messages: z.array(MessagesMessageSchema),
   system: z.union([z.string(), z.array(SystemBlockSchema)]).optional(),
   stream: z.boolean().optional(),
+  trace: TraceSchema,
   temperature: z.number().optional(),
   top_p: z.number().optional(),
   stop_sequences: z.array(z.string()).optional(),

--- a/src/endpoints/responses/handler.ts
+++ b/src/endpoints/responses/handler.ts
@@ -87,15 +87,15 @@ export const responses = (config: GatewayConfig): Endpoint => {
     logger.debug(`[responses] using ${languageModel.provider} for ${ctx.resolvedModelId}`);
     addSpanEvent("hebo.provider.resolved");
 
-    const genAiSignalLevel = cfg.telemetry?.signals?.gen_ai;
-    const genAiGeneralAttrs = getGenAiGeneralAttributes(ctx, genAiSignalLevel);
+    ctx.trace ??= ctx.body.trace ?? cfg.telemetry?.signals?.gen_ai;
+    const genAiGeneralAttrs = getGenAiGeneralAttributes(ctx, ctx.trace);
     setSpanAttributes(genAiGeneralAttrs);
 
-    const { model: _model, stream, ...inputs } = ctx.body;
+    const { model: _model, stream, trace: _trace, ...inputs } = ctx.body;
     const textOptions = convertToTextCallOptions(inputs as ResponsesInputs);
     logger.trace({ requestId: ctx.requestId, options: textOptions }, "[responses] AI SDK options");
     addSpanEvent("hebo.options.prepared");
-    setSpanAttributes(getResponsesRequestAttributes(ctx.body, genAiSignalLevel));
+    setSpanAttributes(getResponsesRequestAttributes(ctx.body, ctx.trace));
 
     const languageModelWithMiddleware = wrapLanguageModel({
       model: languageModel,
@@ -119,7 +119,7 @@ export const responses = (config: GatewayConfig): Endpoint => {
         onChunk: () => {
           if (!ttft) {
             ttft = performance.now() - start;
-            recordTimeToFirstToken(ttft, genAiGeneralAttrs, genAiSignalLevel);
+            recordTimeToFirstToken(ttft, genAiGeneralAttrs, ctx.trace);
           }
         },
         onFinish: (res) => {
@@ -134,18 +134,12 @@ export const responses = (config: GatewayConfig): Endpoint => {
 
           const genAiResponseAttrs = getResponsesResponseAttributes(
             streamResult,
-            genAiSignalLevel,
+            ctx.trace,
             res.finishReason,
           );
           setSpanAttributes(genAiResponseAttrs);
-          recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, genAiSignalLevel);
-          recordTimePerOutputToken(
-            start,
-            ttft,
-            genAiResponseAttrs,
-            genAiGeneralAttrs,
-            genAiSignalLevel,
-          );
+          recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
+          recordTimePerOutputToken(start, ttft, genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
         },
         experimental_include: {
           requestBody: false,
@@ -178,7 +172,7 @@ export const responses = (config: GatewayConfig): Endpoint => {
     });
     logger.trace({ requestId: ctx.requestId, result }, "[responses] AI SDK result");
     addSpanEvent("hebo.ai-sdk.completed");
-    recordTimeToFirstToken(performance.now() - start, genAiGeneralAttrs, genAiSignalLevel);
+    recordTimeToFirstToken(performance.now() - start, genAiGeneralAttrs, ctx.trace);
 
     ctx.result = toResponses(result, ctx.resolvedModelId, ctx.body.metadata);
     logger.trace({ requestId: ctx.requestId, result: ctx.result }, "[responses] Responses");
@@ -186,18 +180,18 @@ export const responses = (config: GatewayConfig): Endpoint => {
 
     const genAiResponseAttrs = getResponsesResponseAttributes(
       ctx.result,
-      genAiSignalLevel,
+      ctx.trace,
       result.finishReason,
     );
     setSpanAttributes(genAiResponseAttrs);
-    recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, genAiSignalLevel);
+    recordTokenUsage(genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
 
     if (hooks?.after) {
       ctx.result = (await hooks.after(ctx as AfterHookContext)) ?? ctx.result;
       addSpanEvent("hebo.hooks.after.completed");
     }
 
-    recordTimePerOutputToken(start, 0, genAiResponseAttrs, genAiGeneralAttrs, genAiSignalLevel);
+    recordTimePerOutputToken(start, 0, genAiResponseAttrs, genAiGeneralAttrs, ctx.trace);
     return ctx.result;
   };
 

--- a/src/endpoints/responses/schema.ts
+++ b/src/endpoints/responses/schema.ts
@@ -221,6 +221,7 @@ import {
   type ProviderMetadata as ResponsesProviderMetadata,
   ContentPartAudioSchema as ResponsesInputAudioSchema,
   type ContentPartAudio as ResponsesInputAudio,
+  TraceSchema,
 } from "../shared/schema";
 
 export {
@@ -348,6 +349,7 @@ export type ResponsesInputs = z.infer<typeof ResponsesInputsSchema>;
 export const ResponsesBodySchema = z.object({
   model: z.string(),
   stream: z.boolean().optional(),
+  trace: TraceSchema,
   ...ResponsesInputsSchema.shape,
 });
 export type ResponsesBody = z.infer<typeof ResponsesBodySchema>;

--- a/src/endpoints/shared/schema.ts
+++ b/src/endpoints/shared/schema.ts
@@ -61,6 +61,17 @@ const InputAudioSchema = z.object({
   format: InputAudioFormatSchema,
 });
 
+/**
+ * Per-request trace control.
+ * Accepts a boolean (`false` → "off", `true` → stripped) or a signal level string.
+ */
+export const TraceSchema = z
+  .union([
+    z.boolean().transform((v) => (v ? undefined : ("off" as const))),
+    z.enum(["off", "required", "recommended", "full"]),
+  ])
+  .optional();
+
 export const ContentPartAudioSchema = z.object({
   type: z.literal("input_audio"),
   input_audio: InputAudioSchema,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -91,7 +91,7 @@ export const winterCgHandler = (
           performance.now() - start,
           realStatus,
           ctx,
-          parsedConfig.telemetry?.signals?.gen_ai,
+          ctx.trace ?? parsedConfig.telemetry?.signals?.gen_ai,
         );
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,12 @@ export type GatewayContext = {
    */
   response?: Response;
   /**
+   * Per-request telemetry signal level override.
+   * When set (via body parameter or hook), overrides `cfg.telemetry.signals.gen_ai`
+   * for this request's span attributes and metrics.
+   */
+  trace?: TelemetrySignalLevel;
+  /**
    * Error thrown during execution.
    */
   error?: unknown;
@@ -102,9 +108,10 @@ export type GatewayContext = {
 /**
  * Hook context: all fields readonly except `state` and `otel`.
  */
-export type HookContext = Omit<Readonly<GatewayContext>, "state" | "otel"> & {
+export type HookContext = Omit<Readonly<GatewayContext>, "state" | "otel" | "trace"> & {
   state: GatewayContext["state"];
   otel: GatewayContext["otel"];
+  trace: GatewayContext["trace"];
 };
 
 type RequiredHookContext<K extends keyof GatewayContext> = Omit<HookContext, K> &


### PR DESCRIPTION
Adds per-request trace control (Option B, Phases 1-3) as discussed in #120.

- `ctx.trace` field on `GatewayContext` (`TelemetrySignalLevel | undefined`)
- `trace` body parameter on all endpoints (`boolean | TelemetrySignalLevel`)
- Signal level resolution inlined as `ctx.trace ??= ctx.body.trace ?? cfg.telemetry?.signals?.gen_ai`
- Hook-set values take precedence over body parameter
- Metrics unaffected

Closes #120

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-request `trace` parameter to control telemetry signal level on individual API requests, overriding global settings when specified.
  * Accepts `false` (equivalent to `"off"`), `true` (uses global default), or explicit values: `"off"`, `"required"`, `"recommended"`, `"full"`.

* **Documentation**
  * Documented Per-Request Trace Control feature and resolution precedence across all supported endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->