### PR TITLE
feat: add Claude Opus 4.7 support with native xhigh effort level

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Out-of-the-box model presets:
   Nova: `nova` (`v1`, `v2`, `v1.x`, `v2.x`, `latest`, `embeddings`, `all`)
 
 - **Anthropic** — `@hebo-ai/gateway/models/anthropic`  
-  Claude: `claude` (`v4.6`, `v4.5`, `v4.1`, `v4`, `v3.7`, `v3.5`, `v3`, `v4.x`, `v3.x`, `haiku`, `sonnet`, `opus`, `latest`, `all`)
+  Claude: `claude` (`v4.7`, `v4.6`, `v4.5`, `v4.1`, `v4`, `v3.7`, `v3.5`, `v3`, `v4.x`, `v3.x`, `haiku`, `sonnet`, `opus`, `latest`, `all`)
 
 - **Cohere** — `@hebo-ai/gateway/models/cohere`  
   Command: `command` (`A`, `R`, `latest`, `all`)
@@ -730,7 +730,7 @@ Normalization rules:
 
 - `enabled` -> fall-back to model default if none provided
 - `max_tokens`: fall-back to model default if model supports
-- `effort` supports: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
+- `effort` supports: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`
 - Generic `effort` -> budget = percentage of `max_tokens`
   - `none`: 0%
   - `minimal`: 10%
@@ -738,6 +738,7 @@ Normalization rules:
   - `medium`: 50% (default)
   - `high`: 80%
   - `xhigh`: 95%
+  - `max`: 100%
 
 Reasoning output is surfaced as extension to the `completion` object.
 

--- a/src/endpoints/shared/schema.ts
+++ b/src/endpoints/shared/schema.ts
@@ -22,7 +22,15 @@ export const ProviderMetadataSchema = z.record(
 ) as z.ZodType<SharedV3ProviderMetadata>;
 export type ProviderMetadata = SharedV3ProviderMetadata;
 
-export const ReasoningEffortSchema = z.enum(["none", "minimal", "low", "medium", "high", "xhigh"]);
+export const ReasoningEffortSchema = z.enum([
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
 export type ReasoningEffort = z.infer<typeof ReasoningEffortSchema>;
 
 export const ReasoningSummarySchema = z.enum(["auto", "concise", "detailed", "none"]);

--- a/src/middleware/utils.ts
+++ b/src/middleware/utils.ts
@@ -25,6 +25,9 @@ export function calculateReasoningBudgetFromEffort(
     case "xhigh":
       percentage = 0.95;
       break;
+    case "max":
+      percentage = 1.0;
+      break;
   }
 
   return Math.max(minTokens, Math.floor(maxTokens * percentage));

--- a/src/models/amazon/middleware.ts
+++ b/src/models/amazon/middleware.ts
@@ -46,6 +46,7 @@ function mapNovaEffort(
       return "medium";
     case "high":
     case "xhigh":
+    case "max":
       return "high";
   }
 

--- a/src/models/anthropic/middleware.test.ts
+++ b/src/models/anthropic/middleware.test.ts
@@ -8,6 +8,7 @@ import { claudePromptCachingMiddleware, claudeReasoningMiddleware } from "./midd
 
 test("claudeReasoningMiddleware > matching patterns", () => {
   const matching = [
+    "anthropic/claude-opus-4.7",
     "anthropic/claude-opus-4.6",
     "anthropic/claude-sonnet-4.6",
     "anthropic/claude-sonnet-3.7",
@@ -370,6 +371,106 @@ test("claudeReasoningMiddleware > should map xhigh effort to max for Claude Opus
           type: "adaptive",
         },
         effort: "max",
+      },
+      unknown: {},
+    },
+  });
+});
+
+test("claudeReasoningMiddleware > should map xhigh effort to native xhigh for Claude Opus 4.7", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: {
+          enabled: true,
+          effort: "xhigh",
+        },
+      },
+    },
+  };
+
+  const result = await claudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4.7" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "xhigh",
+      },
+      unknown: {},
+    },
+  });
+});
+
+test("claudeReasoningMiddleware > should clamp max_tokens to 128k for Claude Opus 4.7", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: {
+          enabled: true,
+          effort: "medium",
+          max_tokens: 200000,
+        },
+      },
+    },
+  };
+
+  const result = await claudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4.7" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "medium",
+      },
+      unknown: {},
+    },
+  });
+});
+
+test("claudeReasoningMiddleware > should use adaptive thinking without budget for Claude Opus 4.7", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: {
+          enabled: true,
+          effort: "high",
+        },
+      },
+    },
+  };
+
+  const result = await claudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4.7" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "high",
       },
       unknown: {},
     },

--- a/src/models/anthropic/middleware.test.ts
+++ b/src/models/anthropic/middleware.test.ts
@@ -410,7 +410,7 @@ test("claudeReasoningMiddleware > should map xhigh effort to native xhigh for Cl
   });
 });
 
-test("claudeReasoningMiddleware > should clamp max_tokens to 128k for Claude Opus 4.7", async () => {
+test("claudeReasoningMiddleware > should ignore max_tokens for Claude Opus 4.7 (adaptive only)", async () => {
   const params = {
     prompt: [],
     providerOptions: {
@@ -442,6 +442,7 @@ test("claudeReasoningMiddleware > should clamp max_tokens to 128k for Claude Opu
       unknown: {},
     },
   });
+  expect(result.providerOptions!["anthropic"]!["thinking"]).not.toHaveProperty("budgetTokens");
 });
 
 test("claudeReasoningMiddleware > should use adaptive thinking without budget for Claude Opus 4.7", async () => {
@@ -745,6 +746,106 @@ test("claudeReasoningMiddleware > should keep xhigh as budget for non-4.6 models
         thinking: {
           type: "enabled",
           budgetTokens: 60800,
+        },
+      },
+      unknown: {},
+    },
+  });
+});
+
+test("claudeReasoningMiddleware > should map max effort to native max for Claude Opus 4.7", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: {
+          enabled: true,
+          effort: "max",
+        },
+      },
+    },
+  };
+
+  const result = await claudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4.7" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "max",
+      },
+      unknown: {},
+    },
+  });
+});
+
+test("claudeReasoningMiddleware > should map max effort to max for Claude Opus 4.6", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: {
+          enabled: true,
+          effort: "max",
+        },
+      },
+    },
+  };
+
+  const result = await claudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4.6" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "max",
+      },
+      unknown: {},
+    },
+  });
+});
+
+test("claudeReasoningMiddleware > should map max effort to high for non-Opus models", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: {
+          enabled: true,
+          effort: "max",
+        },
+      },
+    },
+  };
+
+  const result = await claudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-sonnet-4.5" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      anthropic: {
+        effort: "high",
+        thinking: {
+          type: "enabled",
+          budgetTokens: 64000,
         },
       },
       unknown: {},

--- a/src/models/anthropic/middleware.ts
+++ b/src/models/anthropic/middleware.ts
@@ -40,6 +40,8 @@ export function mapClaudeReasoningEffort(
         return "high";
       case "xhigh":
         return "xhigh";
+      case "max":
+        return "max";
     }
   }
 
@@ -54,6 +56,7 @@ export function mapClaudeReasoningEffort(
       case "high":
         return "high";
       case "xhigh":
+      case "max":
         return "max";
     }
   }
@@ -67,6 +70,7 @@ export function mapClaudeReasoningEffort(
       return "medium";
     case "high":
     case "xhigh":
+    case "max":
       return "high";
   }
 

--- a/src/models/anthropic/middleware.ts
+++ b/src/models/anthropic/middleware.ts
@@ -18,6 +18,7 @@ const isClaude = (family: "opus" | "sonnet" | "haiku", version: string) => {
 
 const isClaude4 = (modelId: string) => modelId.includes("claude-") && modelId.includes("-4");
 
+const isOpus47 = isClaude("opus", "4.7");
 const isOpus46 = isClaude("opus", "4.6");
 const isOpus45 = isClaude("opus", "4.5");
 const isOpus4 = isClaude("opus", "4");
@@ -26,7 +27,22 @@ const isSonnet46 = isClaude("sonnet", "4.6");
 export function mapClaudeReasoningEffort(
   effort: ChatCompletionsReasoningEffort,
   modelId: string,
-): "low" | "medium" | "high" | "max" | undefined {
+): "low" | "medium" | "high" | "xhigh" | "max" | undefined {
+  if (isOpus47(modelId)) {
+    switch (effort) {
+      case "none":
+      case "minimal":
+      case "low":
+        return "low";
+      case "medium":
+        return "medium";
+      case "high":
+        return "high";
+      case "xhigh":
+        return "xhigh";
+    }
+  }
+
   if (isOpus46(modelId)) {
     switch (effort) {
       case "none":
@@ -58,6 +74,7 @@ export function mapClaudeReasoningEffort(
 }
 
 function getMaxOutputTokens(modelId: string): number {
+  if (isOpus47(modelId)) return 128_000;
   if (isOpus46(modelId)) return 128_000;
   if (isOpus45(modelId)) return 64_000;
   if (isOpus4(modelId)) return 32_000;
@@ -87,9 +104,12 @@ export const claudeReasoningMiddleware: LanguageModelMiddleware = {
       target.thinking = { type: "disabled" };
     } else if (reasoning.effort) {
       if (isClaude4(modelId)) {
+        // @ts-expect-error AI SDK type missing "xhigh" effort level (native on Opus 4.7+)
         target.effort = mapClaudeReasoningEffort(reasoning.effort, modelId);
       }
-      if (isOpus46(modelId)) {
+      if (isOpus47(modelId)) {
+        target.thinking = { type: "adaptive" };
+      } else if (isOpus46(modelId)) {
         target.thinking = clampedMaxTokens
           ? // @ts-expect-error AI SDK type missing type:adaptive with budgetToken
             { type: "adaptive", budgetTokens: clampedMaxTokens }

--- a/src/models/anthropic/presets.ts
+++ b/src/models/anthropic/presets.ts
@@ -128,6 +128,19 @@ export const claudeOpus45 = presetFor<CanonicalModelId, CatalogModel>()(
   } satisfies DeepPartial<CatalogModel>,
 );
 
+export const claudeOpus47 = presetFor<CanonicalModelId, CatalogModel>()(
+  "anthropic/claude-opus-4.7" as const,
+  {
+    ...CLAUDE_BASE,
+    ...CLAUDE_PDF_MODALITIES,
+    name: "Claude Opus 4.7",
+    capabilities: [...CLAUDE_BASE.capabilities, "reasoning"],
+    context: 1_000_000,
+    created: "2026-04-16",
+    knowledge: "2026-01",
+  } satisfies DeepPartial<CatalogModel>,
+);
+
 export const claudeOpus46 = presetFor<CanonicalModelId, CatalogModel>()(
   "anthropic/claude-opus-4.6" as const,
   {
@@ -165,6 +178,7 @@ export const claudeOpus4 = presetFor<CanonicalModelId, CatalogModel>()(
 );
 
 const claudeAtomic = {
+  "v4.7": [claudeOpus47],
   "v4.6": [claudeSonnet46, claudeOpus46],
   "v4.5": [claudeHaiku45, claudeSonnet45, claudeOpus45],
   "v4.1": [claudeOpus41],
@@ -174,11 +188,12 @@ const claudeAtomic = {
   v3: [claudeHaiku3],
   haiku: [claudeHaiku45, claudeHaiku35, claudeHaiku3],
   sonnet: [claudeSonnet46, claudeSonnet45, claudeSonnet4, claudeSonnet37, claudeSonnet35],
-  opus: [claudeOpus46, claudeOpus45, claudeOpus41, claudeOpus4],
+  opus: [claudeOpus47, claudeOpus46, claudeOpus45, claudeOpus41, claudeOpus4],
 } as const;
 
 const claudeGroups = {
   "v4.x": [
+    ...claudeAtomic["v4.7"],
     ...claudeAtomic["v4.6"],
     ...claudeAtomic["v4.5"],
     ...claudeAtomic["v4.1"],
@@ -190,6 +205,6 @@ const claudeGroups = {
 export const claude = {
   ...claudeAtomic,
   ...claudeGroups,
-  latest: [...claudeAtomic["v4.6"]],
+  latest: [...claudeAtomic["v4.7"], ...claudeAtomic["v4.6"]],
   all: Object.values(claudeAtomic).flat(),
 } as const;

--- a/src/models/google/middleware.ts
+++ b/src/models/google/middleware.ts
@@ -45,6 +45,7 @@ export function mapGeminiReasoningEffort(
         return "medium";
       case "high":
       case "xhigh":
+      case "max":
         return "high";
     }
   }
@@ -60,6 +61,7 @@ export function mapGeminiReasoningEffort(
       return "medium";
     case "high":
     case "xhigh":
+    case "max":
       return "high";
   }
 

--- a/src/models/openai/middleware.ts
+++ b/src/models/openai/middleware.ts
@@ -40,6 +40,7 @@ function mapGptOssReasoningEffort(
       return "medium";
     case "high":
     case "xhigh":
+    case "max":
       return "high";
   }
 
@@ -65,7 +66,7 @@ export const openAIReasoningMiddleware: LanguageModelMiddleware = {
     } else if (reasoning.enabled === false) {
       target.reasoningEffort = "none";
     } else if (reasoning.effort) {
-      target.reasoningEffort = reasoning.effort;
+      target.reasoningEffort = reasoning.effort === "max" ? "xhigh" : reasoning.effort;
     }
 
     // FUTURE: warn that reasoning.max_tokens (not supported) was ignored

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -2,6 +2,7 @@ import type { ProviderId } from "../providers/types";
 
 export const CANONICAL_MODEL_IDS = [
   // Anthropic
+  "anthropic/claude-opus-4.7",
   "anthropic/claude-opus-4.6",
   "anthropic/claude-sonnet-4.6",
   "anthropic/claude-haiku-4.5",

--- a/src/providers/bedrock/canonical.ts
+++ b/src/providers/bedrock/canonical.ts
@@ -12,6 +12,7 @@ import { withCanonicalIds } from "../registry";
 const MAPPING = {
   // Require Inference Profiles and can't be resolved from standard name mapping
   "anthropic/claude-haiku-4.5": "{ip}anthropic.claude-haiku-4-5-20251001-v1:0",
+  "anthropic/claude-opus-4.7": "{ip}anthropic.claude-opus-4-7",
   "anthropic/claude-sonnet-4.6": "{ip}anthropic.claude-sonnet-4-6",
   "anthropic/claude-sonnet-4.5": "{ip}anthropic.claude-sonnet-4-5-20250929-v1:0",
   "anthropic/claude-opus-4.6": "{ip}anthropic.claude-opus-4-6-v1",

--- a/src/providers/bedrock/middleware.test.ts
+++ b/src/providers/bedrock/middleware.test.ts
@@ -374,6 +374,50 @@ test("bedrockClaudeReasoningMiddleware > should skip non-claude models", async (
   });
 });
 
+test("bedrock middlewares > matching provider resolves Claude middleware for Opus 4.7", () => {
+  const middleware = modelMiddlewareMatcher.resolve({
+    kind: "text",
+    modelId: "anthropic/claude-opus-4.7",
+    providerId: "amazon-bedrock",
+  });
+
+  expect(middleware).toContain(bedrockClaudeReasoningMiddleware);
+  expect(middleware).toContain(bedrockServiceTierMiddleware);
+});
+
+test("bedrockClaudeReasoningMiddleware > should set maxReasoningEffort for Claude Opus 4.7", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      bedrock: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "xhigh",
+      },
+    },
+  };
+
+  const result = await bedrockClaudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4-7" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      bedrock: {
+        reasoningConfig: {
+          type: "enabled",
+          budgetTokens: 62259,
+          maxReasoningEffort: "xhigh",
+        },
+      },
+    },
+  });
+});
+
 test("bedrockClaudeReasoningMiddleware > should not set maxReasoningEffort for Claude 3.x", async () => {
   const params = {
     prompt: [],

--- a/src/providers/bedrock/middleware.ts
+++ b/src/providers/bedrock/middleware.ts
@@ -12,7 +12,8 @@ import type {
 import { modelMiddlewareMatcher } from "../../middleware/matcher";
 import { calculateReasoningBudgetFromEffort } from "../../middleware/utils";
 
-const isClaude46 = (modelId: string) => modelId.includes("-4-6");
+const isClaude46or47 = (modelId: string) =>
+  modelId.includes("-4-6") || modelId.includes("-4-7");
 
 // https://docs.aws.amazon.com/bedrock/latest/userguide/service-tiers-inference.html
 export const bedrockServiceTierMiddleware: LanguageModelMiddleware = {
@@ -109,7 +110,7 @@ export const bedrockClaudeReasoningMiddleware: LanguageModelMiddleware = {
     }
 
     // FUTURE: bedrock currently does not support "effort" for other 4.x models
-    if (effort !== undefined && isClaude46(model.modelId)) {
+    if (effort !== undefined && isClaude46or47(model.modelId)) {
       target.maxReasoningEffort = effort;
     }
 

--- a/src/providers/bedrock/middleware.ts
+++ b/src/providers/bedrock/middleware.ts
@@ -12,8 +12,9 @@ import type {
 import { modelMiddlewareMatcher } from "../../middleware/matcher";
 import { calculateReasoningBudgetFromEffort } from "../../middleware/utils";
 
-const isClaude46or47 = (modelId: string) =>
-  modelId.includes("-4-6") || modelId.includes("-4-7");
+const BEDROCK_EFFORT_CAPABLE = ["-4-6", "-4-7"] as const;
+const isBedrockEffortCapable = (modelId: string) =>
+  BEDROCK_EFFORT_CAPABLE.some((tag) => modelId.includes(tag));
 
 // https://docs.aws.amazon.com/bedrock/latest/userguide/service-tiers-inference.html
 export const bedrockServiceTierMiddleware: LanguageModelMiddleware = {
@@ -110,7 +111,7 @@ export const bedrockClaudeReasoningMiddleware: LanguageModelMiddleware = {
     }
 
     // FUTURE: bedrock currently does not support "effort" for other 4.x models
-    if (effort !== undefined && isClaude46or47(model.modelId)) {
+    if (effort !== undefined && isBedrockEffortCapable(model.modelId)) {
       target.maxReasoningEffort = effort;
     }
 


### PR DESCRIPTION
Add Claude Opus 4.7 support with canonical model ID, preset (1M context, 128k max output, knowledge cutoff Jan 2026), Bedrock mapping, and middleware.

Key differences from Opus 4.6:
- Native xhigh effort level (4.6 maps xhigh → max)
- Adaptive thinking only (no extended thinking / budget_tokens)
- 1M token context window

Note: models.dev/api.json does not yet include Opus 4.7. Dates sourced from Anthropic platform docs.

Closes #125

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Opus 4.7 with reasoning capabilities and expanded context.
  * Introduced "xhigh" and "max" reasoning effort options, with "max" using full-token budgeting.
  * Default model selection updated to prefer v4.7 presets.

* **Bug Fixes / Behavior**
  * Reasoning effort handling and token-budget calculations refined across providers to honor new effort levels.

* **Tests**
  * Added tests validating Opus 4.7 matching and reasoning mappings.

* **Documentation**
  * README updated to document v4.7 and the "max" effort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->