### PR TITLE
fix: only set span ERROR status for 5xx and upstream errors

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -77,7 +77,9 @@ export const winterCgHandler = (
           err: reason ?? ctx.request.signal.reason,
         });
 
-        span.recordError(reason);
+        const isUpstreamError =
+          reason instanceof GatewayError && reason.code.startsWith("UPSTREAM_");
+        span.recordError(reason, realStatus >= 500 || isUpstreamError);
       }
       span.setAttributes({ "http.response.status_code_effective": realStatus });
 

--- a/src/telemetry/span.ts
+++ b/src/telemetry/span.ts
@@ -10,7 +10,7 @@ let spanEventsEnabled = false;
 
 const NOOP_SPAN = {
   runWithContext: <T>(fn: () => Promise<T> | T) => fn(),
-  recordError: (_error: unknown) => {},
+  recordError: (_error: unknown, _setError: boolean) => {},
   finish: () => {},
   isExisting: true,
 };
@@ -40,10 +40,12 @@ export const startSpan = (name: string, options?: SpanOptions) => {
   const runWithContext = <T>(fn: () => Promise<T> | T) =>
     context.with(trace.setSpan(parentContext, span), fn);
 
-  const recordError = (error: unknown) => {
+  const recordError = (error: unknown, setError: boolean) => {
     const err = error instanceof Error ? error : new Error(String(error));
     span.recordException(err);
-    span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+    if (setError) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+    }
   };
 
   const finish = () => {
@@ -66,7 +68,7 @@ export const withSpan = async <T>(
   try {
     return await started.runWithContext(run);
   } catch (error) {
-    started.recordError(error);
+    started.recordError(error, true);
     throw error;
   } finally {
     started.finish();


### PR DESCRIPTION
Align SpanStatusCode to OTel HTTP semantic conventions: leave span status UNSET for 4xx responses (client errors) and only set ERROR for 5xx or upstream failures. Keep setStatus logic centralized in recordError with a boolean parameter.

Closes #124

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error classification in telemetry to better distinguish upstream errors from other server-side failures.
  * Refined error severity flagging to account for both HTTP status codes and upstream error types, improving error reporting accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->