### PR TITLE
feat: forward upstream retry headers (x-should-retry, retry-after, retry-after-ms)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -21,5 +21,5 @@
     "no-unsafe-type-assertion": "off",
     "strict-boolean-expressions": "off"
   },
-  "ignorePatterns": ["dist/**", "node_modules/**", "e2e/**"]
+  "ignorePatterns": ["dist/**", "node_modules/**", "examples/**"]
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ These examples use the root dev dependencies, so run `bun install` at the repo r
 ### Elysia
 
 ```sh
-cd e2e/elysia
+cd examples/elysia
 bun index.ts
 ```
 
@@ -25,7 +25,7 @@ Route: `/v1/gateway/models`
 ### Hono
 
 ```sh
-cd e2e/hono
+cd examples/hono
 bun index.ts
 ```
 
@@ -34,7 +34,7 @@ Route: `/v1/gateway/models`
 ### Next.js
 
 ```sh
-cd e2e/next
+cd examples/next
 bun --bun next dev
 ```
 
@@ -46,7 +46,7 @@ Routes:
 ### TanStack
 
 ```sh
-cd e2e/tanstack
+cd examples/tanstack
 bun --bun vite dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hebo-ai/gateway",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "AI gateway as a framework. For full control over models, routing & lifecycle. OpenAI /chat/completions, OpenResponses /responses & Anthropic /messages.",
   "keywords": [
     "ai",

--- a/src/endpoints/chat-completions/handler.ts
+++ b/src/endpoints/chat-completions/handler.ts
@@ -187,6 +187,7 @@ export const chatCompletions = (config: GatewayConfig): Endpoint => {
     });
     logger.trace({ requestId: ctx.requestId, result }, "[chat] AI SDK result");
     addSpanEvent("hebo.ai-sdk.completed");
+    if (result.response.headers) ctx.response = { headers: result.response.headers };
     recordTimeToFirstToken(performance.now() - start, genAiGeneralAttrs, ctx.trace);
 
     // Transform result.

--- a/src/endpoints/embeddings/handler.ts
+++ b/src/endpoints/embeddings/handler.ts
@@ -112,6 +112,7 @@ export const embeddings = (config: GatewayConfig): Endpoint => {
     });
     logger.trace({ requestId: ctx.requestId, result }, "[embeddings] AI SDK result");
     addSpanEvent("hebo.ai-sdk.completed");
+    if (result.responses?.[0]?.headers) ctx.response = { headers: result.responses[0].headers };
 
     // Transform result.
     ctx.result = toEmbeddings(result, ctx.modelId);

--- a/src/endpoints/messages/handler.ts
+++ b/src/endpoints/messages/handler.ts
@@ -172,6 +172,7 @@ export const messages = (config: GatewayConfig): Endpoint => {
     });
     logger.trace({ requestId: ctx.requestId, result }, "[messages] AI SDK result");
     addSpanEvent("hebo.ai-sdk.completed");
+    if (result.response.headers) ctx.response = { headers: result.response.headers };
     recordTimeToFirstToken(performance.now() - start, genAiGeneralAttrs, ctx.trace);
 
     ctx.result = toMessages(result, ctx.resolvedModelId);

--- a/src/endpoints/responses/converters.test.ts
+++ b/src/endpoints/responses/converters.test.ts
@@ -798,17 +798,14 @@ describe("Responses Converters", () => {
 
       // Content deltas (parallel to summary)
       const contentDeltas = events.filter(
-        (e): e is ResponseReasoningTextDeltaEvent =>
-          e.event === "response.reasoning_text.delta",
+        (e): e is ResponseReasoningTextDeltaEvent => e.event === "response.reasoning_text.delta",
       );
       expect(contentDeltas).toHaveLength(2);
       expect(contentDeltas[0]!.data.delta).toBe("Let me");
       expect(contentDeltas[1]!.data.delta).toBe(" think...");
 
       // Content text done event
-      const contentTextDone = events.filter(
-        (e) => e.event === "response.reasoning_text.done",
-      );
+      const contentTextDone = events.filter((e) => e.event === "response.reasoning_text.done");
       expect(contentTextDone).toHaveLength(1);
 
       // Text

--- a/src/endpoints/responses/handler.ts
+++ b/src/endpoints/responses/handler.ts
@@ -172,6 +172,7 @@ export const responses = (config: GatewayConfig): Endpoint => {
     });
     logger.trace({ requestId: ctx.requestId, result }, "[responses] AI SDK result");
     addSpanEvent("hebo.ai-sdk.completed");
+    if (result.response.headers) ctx.response = { headers: result.response.headers };
     recordTimeToFirstToken(performance.now() - start, genAiGeneralAttrs, ctx.trace);
 
     ctx.result = toResponses(result, ctx.resolvedModelId, ctx.body.metadata);

--- a/src/errors/ai-sdk.ts
+++ b/src/errors/ai-sdk.ts
@@ -39,11 +39,22 @@ import {
 import { GatewayError } from "./gateway";
 import { STATUS_CODE } from "./utils";
 
+const normalizeApiCallError = (error: APICallError): GatewayError => {
+  const status = error.statusCode ?? (error.isRetryable ? 502 : 422);
+  const code = `UPSTREAM_${STATUS_CODE(status)}`;
+  return new GatewayError(error, status, code, undefined, error.responseHeaders);
+};
+
 export const normalizeAiSdkError = (error: unknown): GatewayError | undefined => {
   if (APICallError.isInstance(error)) {
-    const status = error.statusCode ?? (error.isRetryable ? 502 : 422);
-    const code = `UPSTREAM_${STATUS_CODE(status)}`;
-    return new GatewayError(error, status, code);
+    return normalizeApiCallError(error);
+  }
+
+  if (RetryError.isInstance(error)) {
+    if (APICallError.isInstance(error.lastError)) {
+      return normalizeApiCallError(error.lastError);
+    }
+    return new GatewayError(error, 502, `UPSTREAM_${STATUS_CODE(502)}`);
   }
 
   if (
@@ -55,7 +66,6 @@ export const normalizeAiSdkError = (error: unknown): GatewayError | undefined =>
     NoOutputGeneratedError.isInstance(error) ||
     InvalidStreamPartError.isInstance(error) ||
     UIMessageStreamError.isInstance(error) ||
-    RetryError.isInstance(error) ||
     DownloadError.isInstance(error) ||
     ToolCallRepairError.isInstance(error) ||
     NoImageGeneratedError.isInstance(error) ||

--- a/src/errors/ai-sdk.ts
+++ b/src/errors/ai-sdk.ts
@@ -37,12 +37,12 @@ import {
 } from "ai";
 
 import { GatewayError } from "./gateway";
-import { STATUS_CODE } from "./utils";
+import { STATUS_TEXT } from "./utils";
 
 const normalizeApiCallError = (error: APICallError): GatewayError => {
   const status = error.statusCode ?? (error.isRetryable ? 502 : 422);
-  const code = `UPSTREAM_${STATUS_CODE(status)}`;
-  return new GatewayError(error, status, code, undefined, error.responseHeaders ?? undefined);
+  const statusText = `UPSTREAM_${STATUS_TEXT(status)}`;
+  return new GatewayError(error, status, statusText, undefined, error.responseHeaders ?? undefined);
 };
 
 export const normalizeAiSdkError = (error: unknown): GatewayError | undefined => {
@@ -54,7 +54,7 @@ export const normalizeAiSdkError = (error: unknown): GatewayError | undefined =>
     if (APICallError.isInstance(error.lastError)) {
       return normalizeApiCallError(error.lastError);
     }
-    return new GatewayError(error, 502, `UPSTREAM_${STATUS_CODE(502)}`);
+    return new GatewayError(error, 502, `UPSTREAM_${STATUS_TEXT(502)}`);
   }
 
   if (
@@ -74,7 +74,7 @@ export const normalizeAiSdkError = (error: unknown): GatewayError | undefined =>
     NoTranscriptGeneratedError.isInstance(error) ||
     NoVideoGeneratedError.isInstance(error)
   ) {
-    return new GatewayError(error, 502, `UPSTREAM_${STATUS_CODE(502)}`);
+    return new GatewayError(error, 502, `UPSTREAM_${STATUS_TEXT(502)}`);
   }
 
   if (
@@ -94,7 +94,7 @@ export const normalizeAiSdkError = (error: unknown): GatewayError | undefined =>
     NoSuchModelError.isInstance(error) ||
     NoSuchProviderError.isInstance(error)
   ) {
-    return new GatewayError(error, 422, `UPSTREAM_${STATUS_CODE(422)}`);
+    return new GatewayError(error, 422, `UPSTREAM_${STATUS_TEXT(422)}`);
   }
 
   if (LoadSettingError.isInstance(error) || LoadAPIKeyError.isInstance(error)) {

--- a/src/errors/ai-sdk.ts
+++ b/src/errors/ai-sdk.ts
@@ -42,8 +42,7 @@ import { STATUS_CODE } from "./utils";
 const normalizeApiCallError = (error: APICallError): GatewayError => {
   const status = error.statusCode ?? (error.isRetryable ? 502 : 422);
   const code = `UPSTREAM_${STATUS_CODE(status)}`;
-  const response = error.responseHeaders ? { headers: error.responseHeaders } : undefined;
-  return new GatewayError(error, status, code, undefined, response);
+  return new GatewayError(error, status, code, undefined, error.responseHeaders ?? undefined);
 };
 
 export const normalizeAiSdkError = (error: unknown): GatewayError | undefined => {

--- a/src/errors/ai-sdk.ts
+++ b/src/errors/ai-sdk.ts
@@ -42,7 +42,8 @@ import { STATUS_CODE } from "./utils";
 const normalizeApiCallError = (error: APICallError): GatewayError => {
   const status = error.statusCode ?? (error.isRetryable ? 502 : 422);
   const code = `UPSTREAM_${STATUS_CODE(status)}`;
-  return new GatewayError(error, status, code, undefined, error.responseHeaders);
+  const response = error.responseHeaders ? { headers: error.responseHeaders } : undefined;
+  return new GatewayError(error, status, code, undefined, response);
 };
 
 export const normalizeAiSdkError = (error: unknown): GatewayError | undefined => {

--- a/src/errors/anthropic.ts
+++ b/src/errors/anthropic.ts
@@ -1,7 +1,7 @@
 import * as z from "zod";
 
-import { buildRetryHeaders } from "../utils/headers";
-import { prepareResponseInit, toResponse } from "../utils/response";
+import { resolveRequestId } from "../utils/headers";
+import { toResponse } from "../utils/response";
 import { getErrorMeta, maybeMaskMessage } from "./utils";
 
 export const AnthropicErrorSchema = z.object({
@@ -15,9 +15,11 @@ export const AnthropicErrorSchema = z.object({
 export class AnthropicError {
   readonly type = "error" as const;
   readonly error: z.infer<typeof AnthropicErrorSchema>["error"];
+  declare status: number;
 
   constructor(message: string, type: string = "api_error") {
     this.error = { type, message };
+    Object.defineProperty(this, "status", { value: 500, writable: true });
   }
 }
 
@@ -49,18 +51,25 @@ const mapType = (status: number): string => {
 export function toAnthropicError(error: unknown): AnthropicError {
   const meta = getErrorMeta(error);
 
-  return new AnthropicError(maybeMaskMessage(meta), mapType(meta.status));
+  const anthropicError = new AnthropicError(
+    maybeMaskMessage(error instanceof Error ? error.message : String(error), meta.status),
+    mapType(meta.status),
+  );
+  anthropicError.status = meta.status;
+
+  return anthropicError;
 }
 
-export function toAnthropicErrorResponse(error: unknown, requestId: string): Response {
-  const meta = getErrorMeta(error);
-  const responseInit = prepareResponseInit(requestId, {
-    headers: buildRetryHeaders(meta.status, meta.headers as Record<string, string> | undefined),
-  });
-
-  return toResponse(new AnthropicError(maybeMaskMessage(meta, requestId), mapType(meta.status)), {
-    status: meta.status,
-    statusText: meta.code,
-    headers: responseInit.headers,
-  });
+export function toAnthropicErrorResponse(error: unknown, init: ResponseInit): Response {
+  return toResponse(
+    new AnthropicError(
+      maybeMaskMessage(
+        error instanceof Error ? error.message : String(error),
+        init.status ?? 500,
+        resolveRequestId(init),
+      ),
+      mapType(init.status ?? 500),
+    ),
+    init,
+  );
 }

--- a/src/errors/anthropic.ts
+++ b/src/errors/anthropic.ts
@@ -54,9 +54,8 @@ export function toAnthropicError(error: unknown): AnthropicError {
 
 export function toAnthropicErrorResponse(error: unknown, requestId: string): Response {
   const meta = getErrorMeta(error);
-  const upstreamHeaders = meta.response?.headers as Record<string, string> | undefined;
   const responseInit = prepareResponseInit(requestId, {
-    headers: buildRetryHeaders(meta.status, upstreamHeaders),
+    headers: buildRetryHeaders(meta.status, meta.headers as Record<string, string> | undefined),
   });
 
   return toResponse(new AnthropicError(maybeMaskMessage(meta, requestId), mapType(meta.status)), {

--- a/src/errors/anthropic.ts
+++ b/src/errors/anthropic.ts
@@ -48,11 +48,11 @@ const mapType = (status: number): string => {
   }
 };
 
-export function toAnthropicError(error: unknown): AnthropicError {
+export function toAnthropicError(error: unknown, requestId?: string): AnthropicError {
   const meta = getErrorMeta(error);
 
   const anthropicError = new AnthropicError(
-    maybeMaskMessage(error instanceof Error ? error.message : String(error), meta.status),
+    maybeMaskMessage(error instanceof Error ? error.message : String(error), meta.status, requestId),
     mapType(meta.status),
   );
   anthropicError.status = meta.status;

--- a/src/errors/anthropic.ts
+++ b/src/errors/anthropic.ts
@@ -19,6 +19,8 @@ export class AnthropicError {
 
   constructor(message: string, type: string = "api_error") {
     this.error = { type, message };
+
+    // internal property to derive status from error handlers without breaking official format
     Object.defineProperty(this, "status", { value: 500, writable: true });
   }
 }

--- a/src/errors/anthropic.ts
+++ b/src/errors/anthropic.ts
@@ -29,12 +29,12 @@ const mapType = (status: number): string => {
       return "invalid_request_error";
     case 401:
       return "authentication_error";
+    case 402:
+      return "billing_error";
     case 403:
       return "permission_error";
     case 404:
       return "not_found_error";
-    case 402:
-      return "billing_error";
     case 413:
       return "request_too_large";
     case 429:

--- a/src/errors/anthropic.ts
+++ b/src/errors/anthropic.ts
@@ -1,7 +1,7 @@
 import * as z from "zod";
 
-import { resolveRequestId } from "../utils/headers";
-import { toResponse } from "../utils/response";
+import { buildRetryHeaders } from "../utils/headers";
+import { prepareResponseInit, toResponse } from "../utils/response";
 import { getErrorMeta, maybeMaskMessage } from "./utils";
 
 export const AnthropicErrorSchema = z.object({
@@ -52,18 +52,16 @@ export function toAnthropicError(error: unknown): AnthropicError {
   return new AnthropicError(maybeMaskMessage(meta), mapType(meta.status));
 }
 
-export function toAnthropicErrorResponse(error: unknown, responseInit?: ResponseInit) {
+export function toAnthropicErrorResponse(error: unknown, requestId: string): Response {
   const meta = getErrorMeta(error);
+  const upstreamHeaders = meta.response?.headers as Record<string, string> | undefined;
+  const responseInit = prepareResponseInit(requestId, {
+    headers: buildRetryHeaders(meta.status, upstreamHeaders),
+  });
 
-  return toResponse(
-    new AnthropicError(
-      maybeMaskMessage(meta, resolveRequestId(responseInit)),
-      mapType(meta.status),
-    ),
-    {
-      status: meta.status,
-      statusText: meta.code,
-      headers: responseInit?.headers,
-    },
-  );
+  return toResponse(new AnthropicError(maybeMaskMessage(meta, requestId), mapType(meta.status)), {
+    status: meta.status,
+    statusText: meta.code,
+    headers: responseInit.headers,
+  });
 }

--- a/src/errors/anthropic.ts
+++ b/src/errors/anthropic.ts
@@ -52,7 +52,11 @@ export function toAnthropicError(error: unknown, requestId?: string): AnthropicE
   const meta = getErrorMeta(error);
 
   const anthropicError = new AnthropicError(
-    maybeMaskMessage(error instanceof Error ? error.message : String(error), meta.status, requestId),
+    maybeMaskMessage(
+      error instanceof Error ? error.message : String(error),
+      meta.status,
+      requestId,
+    ),
     mapType(meta.status),
   );
   anthropicError.status = meta.status;

--- a/src/errors/errors.test.ts
+++ b/src/errors/errors.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+
+import { APICallError, RetryError } from "ai";
+
+import { normalizeAiSdkError } from "./ai-sdk";
+import { GatewayError } from "./gateway";
+import { getErrorMeta } from "./utils";
+
+describe("GatewayError", () => {
+  test("carries responseHeaders when provided", () => {
+    const headers = { "retry-after": "5", "x-should-retry": "true" };
+    const error = new GatewayError("test", 429, "TOO_MANY_REQUESTS", undefined, headers);
+    expect(error.responseHeaders).toEqual(headers);
+  });
+
+  test("responseHeaders defaults to undefined", () => {
+    const error = new GatewayError("test", 500);
+    expect(error.responseHeaders).toBeUndefined();
+  });
+});
+
+describe("normalizeAiSdkError", () => {
+  test("extracts responseHeaders from APICallError", () => {
+    const apiError = new APICallError({
+      message: "Too many requests",
+      url: "https://api.openai.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 429,
+      responseHeaders: { "retry-after": "2", "retry-after-ms": "2000" },
+      responseBody: "rate limited",
+    });
+
+    const normalized = normalizeAiSdkError(apiError);
+    expect(normalized).toBeInstanceOf(GatewayError);
+    expect(normalized!.status).toBe(429);
+    expect(normalized!.responseHeaders).toEqual({ "retry-after": "2", "retry-after-ms": "2000" });
+  });
+
+  test("extracts responseHeaders from RetryError wrapping APICallError", () => {
+    const apiError = new APICallError({
+      message: "Service unavailable",
+      url: "https://api.openai.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 503,
+      responseHeaders: { "retry-after": "10" },
+      responseBody: "unavailable",
+    });
+
+    const retryError = new RetryError({
+      message: "Max retries exceeded",
+      reason: "maxRetriesExceeded",
+      errors: [apiError],
+    });
+
+    const normalized = normalizeAiSdkError(retryError);
+    expect(normalized).toBeInstanceOf(GatewayError);
+    expect(normalized!.status).toBe(503);
+    expect(normalized!.responseHeaders).toEqual({ "retry-after": "10" });
+  });
+
+  test("handles RetryError without APICallError inner error", () => {
+    const retryError = new RetryError({
+      message: "Max retries exceeded",
+      reason: "maxRetriesExceeded",
+      errors: [new Error("generic error")],
+    });
+
+    const normalized = normalizeAiSdkError(retryError);
+    expect(normalized).toBeInstanceOf(GatewayError);
+    expect(normalized!.status).toBe(502);
+    expect(normalized!.responseHeaders).toBeUndefined();
+  });
+
+  test("handles APICallError without responseHeaders", () => {
+    const apiError = new APICallError({
+      message: "Bad request",
+      url: "https://api.openai.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 400,
+    });
+
+    const normalized = normalizeAiSdkError(apiError);
+    expect(normalized!.responseHeaders).toBeUndefined();
+  });
+});
+
+describe("getErrorMeta", () => {
+  test("includes responseHeaders from GatewayError", () => {
+    const headers = { "retry-after-ms": "1000" };
+    const error = new GatewayError("test", 429, "TOO_MANY_REQUESTS", undefined, headers);
+    const meta = getErrorMeta(error);
+    expect(meta.responseHeaders).toEqual(headers);
+  });
+
+  test("includes responseHeaders from normalized APICallError", () => {
+    const apiError = new APICallError({
+      message: "Rate limited",
+      url: "https://api.openai.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 429,
+      responseHeaders: { "retry-after": "3" },
+      responseBody: "",
+    });
+
+    const meta = getErrorMeta(apiError);
+    expect(meta.status).toBe(429);
+    expect(meta.responseHeaders).toEqual({ "retry-after": "3" });
+  });
+
+  test("responseHeaders is undefined for non-API errors", () => {
+    const meta = getErrorMeta(new Error("something broke"));
+    expect(meta.responseHeaders).toBeUndefined();
+  });
+
+  test("responseHeaders is undefined for gateway-originated errors", () => {
+    const error = new GatewayError("Model not found", 422, "MODEL_NOT_FOUND");
+    const meta = getErrorMeta(error);
+    expect(meta.responseHeaders).toBeUndefined();
+  });
+});

--- a/src/errors/errors.test.ts
+++ b/src/errors/errors.test.ts
@@ -7,20 +7,20 @@ import { GatewayError } from "./gateway";
 import { getErrorMeta } from "./utils";
 
 describe("GatewayError", () => {
-  test("carries response when provided", () => {
+  test("carries headers when provided", () => {
     const headers = { "retry-after": "5", "x-should-retry": "true" };
-    const error = new GatewayError("test", 429, "TOO_MANY_REQUESTS", undefined, { headers });
-    expect(error.response).toEqual({ headers });
+    const error = new GatewayError("test", 429, "TOO_MANY_REQUESTS", undefined, headers);
+    expect(error.headers).toEqual(headers);
   });
 
-  test("response defaults to undefined", () => {
+  test("headers defaults to undefined", () => {
     const error = new GatewayError("test", 500);
-    expect(error.response).toBeUndefined();
+    expect(error.headers).toBeUndefined();
   });
 });
 
 describe("normalizeAiSdkError", () => {
-  test("wraps responseHeaders from APICallError into ResponseInit", () => {
+  test("passes responseHeaders from APICallError as headers", () => {
     const apiError = new APICallError({
       message: "Too many requests",
       url: "https://api.openai.com/v1/chat/completions",
@@ -33,12 +33,10 @@ describe("normalizeAiSdkError", () => {
     const normalized = normalizeAiSdkError(apiError);
     expect(normalized).toBeInstanceOf(GatewayError);
     expect(normalized!.status).toBe(429);
-    expect(normalized!.response).toEqual({
-      headers: { "retry-after": "2", "retry-after-ms": "2000" },
-    });
+    expect(normalized!.headers).toEqual({ "retry-after": "2", "retry-after-ms": "2000" });
   });
 
-  test("wraps responseHeaders from RetryError wrapping APICallError into ResponseInit", () => {
+  test("passes responseHeaders from RetryError wrapping APICallError as headers", () => {
     const apiError = new APICallError({
       message: "Service unavailable",
       url: "https://api.openai.com/v1/chat/completions",
@@ -57,7 +55,7 @@ describe("normalizeAiSdkError", () => {
     const normalized = normalizeAiSdkError(retryError);
     expect(normalized).toBeInstanceOf(GatewayError);
     expect(normalized!.status).toBe(503);
-    expect(normalized!.response).toEqual({ headers: { "retry-after": "10" } });
+    expect(normalized!.headers).toEqual({ "retry-after": "10" });
   });
 
   test("handles RetryError without APICallError inner error", () => {
@@ -70,7 +68,7 @@ describe("normalizeAiSdkError", () => {
     const normalized = normalizeAiSdkError(retryError);
     expect(normalized).toBeInstanceOf(GatewayError);
     expect(normalized!.status).toBe(502);
-    expect(normalized!.response).toBeUndefined();
+    expect(normalized!.headers).toBeUndefined();
   });
 
   test("handles APICallError without responseHeaders", () => {
@@ -82,19 +80,19 @@ describe("normalizeAiSdkError", () => {
     });
 
     const normalized = normalizeAiSdkError(apiError);
-    expect(normalized!.response).toBeUndefined();
+    expect(normalized!.headers).toBeUndefined();
   });
 });
 
 describe("getErrorMeta", () => {
-  test("includes response from GatewayError", () => {
+  test("includes headers from GatewayError", () => {
     const headers = { "retry-after-ms": "1000" };
-    const error = new GatewayError("test", 429, "TOO_MANY_REQUESTS", undefined, { headers });
+    const error = new GatewayError("test", 429, "TOO_MANY_REQUESTS", undefined, headers);
     const meta = getErrorMeta(error);
-    expect(meta.response).toEqual({ headers });
+    expect(meta.headers).toEqual(headers);
   });
 
-  test("includes response from normalized APICallError", () => {
+  test("includes headers from normalized APICallError", () => {
     const apiError = new APICallError({
       message: "Rate limited",
       url: "https://api.openai.com/v1/chat/completions",
@@ -106,17 +104,17 @@ describe("getErrorMeta", () => {
 
     const meta = getErrorMeta(apiError);
     expect(meta.status).toBe(429);
-    expect(meta.response).toEqual({ headers: { "retry-after": "3" } });
+    expect(meta.headers).toEqual({ "retry-after": "3" });
   });
 
-  test("response is undefined for non-API errors", () => {
+  test("headers is undefined for non-API errors", () => {
     const meta = getErrorMeta(new Error("something broke"));
-    expect(meta.response).toBeUndefined();
+    expect(meta.headers).toBeUndefined();
   });
 
-  test("response is undefined for gateway-originated errors", () => {
+  test("headers is undefined for gateway-originated errors", () => {
     const error = new GatewayError("Model not found", 422, "MODEL_NOT_FOUND");
     const meta = getErrorMeta(error);
-    expect(meta.response).toBeUndefined();
+    expect(meta.headers).toBeUndefined();
   });
 });

--- a/src/errors/errors.test.ts
+++ b/src/errors/errors.test.ts
@@ -13,9 +13,15 @@ describe("GatewayError", () => {
     expect(error.headers).toEqual(headers);
   });
 
-  test("headers defaults to undefined", () => {
+  test("sets x-should-retry false for non-upstream errors", () => {
     const error = new GatewayError("test", 500);
-    expect(error.headers).toBeUndefined();
+    expect(error.headers).toEqual({ "x-should-retry": "false" });
+  });
+
+  test("does not override headers for upstream errors", () => {
+    const headers = { "retry-after": "5" };
+    const error = new GatewayError("test", 502, "UPSTREAM_BAD_GATEWAY", undefined, headers);
+    expect(error.headers).toEqual({ "retry-after": "5" });
   });
 });
 
@@ -112,9 +118,9 @@ describe("getErrorMeta", () => {
     expect(meta.headers).toEqual({});
   });
 
-  test("headers is empty for gateway-originated errors", () => {
+  test("gateway-originated errors carry x-should-retry false", () => {
     const error = new GatewayError("Model not found", 422, "MODEL_NOT_FOUND");
     const meta = getErrorMeta(error);
-    expect(meta.headers).toEqual({});
+    expect(meta.headers).toEqual({ "x-should-retry": "false" });
   });
 });

--- a/src/errors/errors.test.ts
+++ b/src/errors/errors.test.ts
@@ -7,20 +7,20 @@ import { GatewayError } from "./gateway";
 import { getErrorMeta } from "./utils";
 
 describe("GatewayError", () => {
-  test("carries responseHeaders when provided", () => {
+  test("carries response when provided", () => {
     const headers = { "retry-after": "5", "x-should-retry": "true" };
-    const error = new GatewayError("test", 429, "TOO_MANY_REQUESTS", undefined, headers);
-    expect(error.responseHeaders).toEqual(headers);
+    const error = new GatewayError("test", 429, "TOO_MANY_REQUESTS", undefined, { headers });
+    expect(error.response).toEqual({ headers });
   });
 
-  test("responseHeaders defaults to undefined", () => {
+  test("response defaults to undefined", () => {
     const error = new GatewayError("test", 500);
-    expect(error.responseHeaders).toBeUndefined();
+    expect(error.response).toBeUndefined();
   });
 });
 
 describe("normalizeAiSdkError", () => {
-  test("extracts responseHeaders from APICallError", () => {
+  test("wraps responseHeaders from APICallError into ResponseInit", () => {
     const apiError = new APICallError({
       message: "Too many requests",
       url: "https://api.openai.com/v1/chat/completions",
@@ -33,10 +33,12 @@ describe("normalizeAiSdkError", () => {
     const normalized = normalizeAiSdkError(apiError);
     expect(normalized).toBeInstanceOf(GatewayError);
     expect(normalized!.status).toBe(429);
-    expect(normalized!.responseHeaders).toEqual({ "retry-after": "2", "retry-after-ms": "2000" });
+    expect(normalized!.response).toEqual({
+      headers: { "retry-after": "2", "retry-after-ms": "2000" },
+    });
   });
 
-  test("extracts responseHeaders from RetryError wrapping APICallError", () => {
+  test("wraps responseHeaders from RetryError wrapping APICallError into ResponseInit", () => {
     const apiError = new APICallError({
       message: "Service unavailable",
       url: "https://api.openai.com/v1/chat/completions",
@@ -55,7 +57,7 @@ describe("normalizeAiSdkError", () => {
     const normalized = normalizeAiSdkError(retryError);
     expect(normalized).toBeInstanceOf(GatewayError);
     expect(normalized!.status).toBe(503);
-    expect(normalized!.responseHeaders).toEqual({ "retry-after": "10" });
+    expect(normalized!.response).toEqual({ headers: { "retry-after": "10" } });
   });
 
   test("handles RetryError without APICallError inner error", () => {
@@ -68,7 +70,7 @@ describe("normalizeAiSdkError", () => {
     const normalized = normalizeAiSdkError(retryError);
     expect(normalized).toBeInstanceOf(GatewayError);
     expect(normalized!.status).toBe(502);
-    expect(normalized!.responseHeaders).toBeUndefined();
+    expect(normalized!.response).toBeUndefined();
   });
 
   test("handles APICallError without responseHeaders", () => {
@@ -80,19 +82,19 @@ describe("normalizeAiSdkError", () => {
     });
 
     const normalized = normalizeAiSdkError(apiError);
-    expect(normalized!.responseHeaders).toBeUndefined();
+    expect(normalized!.response).toBeUndefined();
   });
 });
 
 describe("getErrorMeta", () => {
-  test("includes responseHeaders from GatewayError", () => {
+  test("includes response from GatewayError", () => {
     const headers = { "retry-after-ms": "1000" };
-    const error = new GatewayError("test", 429, "TOO_MANY_REQUESTS", undefined, headers);
+    const error = new GatewayError("test", 429, "TOO_MANY_REQUESTS", undefined, { headers });
     const meta = getErrorMeta(error);
-    expect(meta.responseHeaders).toEqual(headers);
+    expect(meta.response).toEqual({ headers });
   });
 
-  test("includes responseHeaders from normalized APICallError", () => {
+  test("includes response from normalized APICallError", () => {
     const apiError = new APICallError({
       message: "Rate limited",
       url: "https://api.openai.com/v1/chat/completions",
@@ -104,17 +106,17 @@ describe("getErrorMeta", () => {
 
     const meta = getErrorMeta(apiError);
     expect(meta.status).toBe(429);
-    expect(meta.responseHeaders).toEqual({ "retry-after": "3" });
+    expect(meta.response).toEqual({ headers: { "retry-after": "3" } });
   });
 
-  test("responseHeaders is undefined for non-API errors", () => {
+  test("response is undefined for non-API errors", () => {
     const meta = getErrorMeta(new Error("something broke"));
-    expect(meta.responseHeaders).toBeUndefined();
+    expect(meta.response).toBeUndefined();
   });
 
-  test("responseHeaders is undefined for gateway-originated errors", () => {
+  test("response is undefined for gateway-originated errors", () => {
     const error = new GatewayError("Model not found", 422, "MODEL_NOT_FOUND");
     const meta = getErrorMeta(error);
-    expect(meta.responseHeaders).toBeUndefined();
+    expect(meta.response).toBeUndefined();
   });
 });

--- a/src/errors/errors.test.ts
+++ b/src/errors/errors.test.ts
@@ -107,14 +107,14 @@ describe("getErrorMeta", () => {
     expect(meta.headers).toEqual({ "retry-after": "3" });
   });
 
-  test("headers is undefined for non-API errors", () => {
+  test("headers is empty for non-API errors", () => {
     const meta = getErrorMeta(new Error("something broke"));
-    expect(meta.headers).toBeUndefined();
+    expect(meta.headers).toEqual({});
   });
 
-  test("headers is undefined for gateway-originated errors", () => {
+  test("headers is empty for gateway-originated errors", () => {
     const error = new GatewayError("Model not found", 422, "MODEL_NOT_FOUND");
     const meta = getErrorMeta(error);
-    expect(meta.headers).toBeUndefined();
+    expect(meta.headers).toEqual({});
   });
 });

--- a/src/errors/gateway.ts
+++ b/src/errors/gateway.ts
@@ -1,16 +1,16 @@
-import { STATUS_CODE } from "./utils";
+import { STATUS_TEXT } from "./utils";
 
 export class GatewayError extends Error {
   readonly status: number;
-  readonly code: string;
-  readonly headers: HeadersInit | undefined;
+  readonly statusText: string;
+  readonly headers: Record<string, string> | undefined;
 
   constructor(
     error: unknown,
     status: number,
-    code?: string,
+    statusText?: string,
     cause?: unknown,
-    headers?: HeadersInit,
+    headers?: Record<string, string>,
   ) {
     const isError = error instanceof Error;
     super(isError ? error.message : String(error));
@@ -19,7 +19,7 @@ export class GatewayError extends Error {
     this.cause = cause ?? (isError ? error : undefined);
 
     this.status = status;
-    this.code = code ?? STATUS_CODE(status);
+    this.statusText = statusText ?? STATUS_TEXT(status);
     this.headers = headers;
   }
 }

--- a/src/errors/gateway.ts
+++ b/src/errors/gateway.ts
@@ -3,8 +3,15 @@ import { STATUS_CODE } from "./utils";
 export class GatewayError extends Error {
   readonly status: number;
   readonly code: string;
+  readonly responseHeaders: Record<string, string> | undefined;
 
-  constructor(error: unknown, status: number, code?: string, cause?: unknown) {
+  constructor(
+    error: unknown,
+    status: number,
+    code?: string,
+    cause?: unknown,
+    responseHeaders?: Record<string, string>,
+  ) {
     const isError = error instanceof Error;
     super(isError ? error.message : String(error));
 
@@ -13,5 +20,6 @@ export class GatewayError extends Error {
 
     this.status = status;
     this.code = code ?? STATUS_CODE(status);
+    this.responseHeaders = responseHeaders;
   }
 }

--- a/src/errors/gateway.ts
+++ b/src/errors/gateway.ts
@@ -3,14 +3,14 @@ import { STATUS_CODE } from "./utils";
 export class GatewayError extends Error {
   readonly status: number;
   readonly code: string;
-  readonly responseHeaders: Record<string, string> | undefined;
+  readonly response: ResponseInit | undefined;
 
   constructor(
     error: unknown,
     status: number,
     code?: string,
     cause?: unknown,
-    responseHeaders?: Record<string, string>,
+    response?: ResponseInit,
   ) {
     const isError = error instanceof Error;
     super(isError ? error.message : String(error));
@@ -20,6 +20,6 @@ export class GatewayError extends Error {
 
     this.status = status;
     this.code = code ?? STATUS_CODE(status);
-    this.responseHeaders = responseHeaders;
+    this.response = response;
   }
 }

--- a/src/errors/gateway.ts
+++ b/src/errors/gateway.ts
@@ -3,14 +3,14 @@ import { STATUS_CODE } from "./utils";
 export class GatewayError extends Error {
   readonly status: number;
   readonly code: string;
-  readonly response: ResponseInit | undefined;
+  readonly headers: HeadersInit | undefined;
 
   constructor(
     error: unknown,
     status: number,
     code?: string,
     cause?: unknown,
-    response?: ResponseInit,
+    headers?: HeadersInit,
   ) {
     const isError = error instanceof Error;
     super(isError ? error.message : String(error));
@@ -20,6 +20,6 @@ export class GatewayError extends Error {
 
     this.status = status;
     this.code = code ?? STATUS_CODE(status);
-    this.response = response;
+    this.headers = headers;
   }
 }

--- a/src/errors/gateway.ts
+++ b/src/errors/gateway.ts
@@ -1,3 +1,4 @@
+import { X_SHOULD_RETRY_HEADER } from "../utils/headers";
 import { STATUS_TEXT } from "./utils";
 
 export class GatewayError extends Error {
@@ -21,5 +22,9 @@ export class GatewayError extends Error {
     this.status = status;
     this.statusText = statusText ?? STATUS_TEXT(status);
     this.headers = headers;
+
+    if (!this.statusText.startsWith("UPSTREAM_")) {
+      (this.headers ??= {})[X_SHOULD_RETRY_HEADER] = "false";
+    }
   }
 }

--- a/src/errors/openai.ts
+++ b/src/errors/openai.ts
@@ -1,7 +1,7 @@
 import * as z from "zod";
 
-import { buildRetryHeaders } from "../utils/headers";
-import { prepareResponseInit, toResponse } from "../utils/response";
+import { resolveRequestId } from "../utils/headers";
+import { toResponse } from "../utils/response";
 import { getErrorMeta, maybeMaskMessage } from "./utils";
 
 export const OpenAIErrorSchema = z.object({
@@ -15,9 +15,11 @@ export const OpenAIErrorSchema = z.object({
 
 export class OpenAIError {
   readonly error: z.infer<typeof OpenAIErrorSchema>["error"];
+  declare status: number;
 
   constructor(message: string, type: string = "server_error", code?: string, param: string = "") {
     this.error = { message, type, code: code?.toLowerCase(), param };
+    Object.defineProperty(this, "status", { value: 500, writable: true });
   }
 }
 
@@ -26,21 +28,27 @@ const mapType = (status: number) => (status < 500 ? "invalid_request_error" : "s
 export function toOpenAIError(error: unknown): OpenAIError {
   const meta = getErrorMeta(error);
 
-  return new OpenAIError(maybeMaskMessage(meta), mapType(meta.status), meta.code);
+  const openAIError = new OpenAIError(
+    maybeMaskMessage(error instanceof Error ? error.message : String(error), meta.status),
+    mapType(meta.status),
+    meta.statusText,
+  );
+  openAIError.status = meta.status;
+
+  return openAIError;
 }
 
-export function toOpenAIErrorResponse(error: unknown, requestId: string): Response {
-  const meta = getErrorMeta(error);
-  const responseInit = prepareResponseInit(requestId, {
-    headers: buildRetryHeaders(meta.status, meta.headers as Record<string, string> | undefined),
-  });
-
+export function toOpenAIErrorResponse(error: unknown, init: ResponseInit): Response {
   return toResponse(
-    new OpenAIError(maybeMaskMessage(meta, requestId), mapType(meta.status), meta.code),
-    {
-      status: meta.status,
-      statusText: meta.code,
-      headers: responseInit.headers,
-    },
+    new OpenAIError(
+      maybeMaskMessage(
+        error instanceof Error ? error.message : String(error),
+        init.status ?? 500,
+        resolveRequestId(init),
+      ),
+      mapType(init.status ?? 500),
+      init.statusText ?? "INTERNAL_SERVER_ERROR",
+    ),
+    init,
   );
 }

--- a/src/errors/openai.ts
+++ b/src/errors/openai.ts
@@ -25,11 +25,11 @@ export class OpenAIError {
 
 const mapType = (status: number) => (status < 500 ? "invalid_request_error" : "server_error");
 
-export function toOpenAIError(error: unknown): OpenAIError {
+export function toOpenAIError(error: unknown, requestId?: string): OpenAIError {
   const meta = getErrorMeta(error);
 
   const openAIError = new OpenAIError(
-    maybeMaskMessage(error instanceof Error ? error.message : String(error), meta.status),
+    maybeMaskMessage(error instanceof Error ? error.message : String(error), meta.status, requestId),
     mapType(meta.status),
     meta.statusText,
   );

--- a/src/errors/openai.ts
+++ b/src/errors/openai.ts
@@ -19,6 +19,8 @@ export class OpenAIError {
 
   constructor(message: string, type: string = "server_error", code?: string, param: string = "") {
     this.error = { message, type, code: code?.toLowerCase(), param };
+
+    // internal property to derive status from error handlers without breaking official format
     Object.defineProperty(this, "status", { value: 500, writable: true });
   }
 }

--- a/src/errors/openai.ts
+++ b/src/errors/openai.ts
@@ -1,7 +1,7 @@
 import * as z from "zod";
 
-import { resolveRequestId } from "../utils/headers";
-import { toResponse } from "../utils/response";
+import { buildRetryHeaders } from "../utils/headers";
+import { prepareResponseInit, toResponse } from "../utils/response";
 import { getErrorMeta, maybeMaskMessage } from "./utils";
 
 export const OpenAIErrorSchema = z.object({
@@ -29,19 +29,19 @@ export function toOpenAIError(error: unknown): OpenAIError {
   return new OpenAIError(maybeMaskMessage(meta), mapType(meta.status), meta.code);
 }
 
-export function toOpenAIErrorResponse(error: unknown, responseInit?: ResponseInit) {
+export function toOpenAIErrorResponse(error: unknown, requestId: string): Response {
   const meta = getErrorMeta(error);
+  const upstreamHeaders = meta.response?.headers as Record<string, string> | undefined;
+  const responseInit = prepareResponseInit(requestId, {
+    headers: buildRetryHeaders(meta.status, upstreamHeaders),
+  });
 
   return toResponse(
-    new OpenAIError(
-      maybeMaskMessage(meta, resolveRequestId(responseInit)),
-      mapType(meta.status),
-      meta.code,
-    ),
+    new OpenAIError(maybeMaskMessage(meta, requestId), mapType(meta.status), meta.code),
     {
       status: meta.status,
       statusText: meta.code,
-      headers: responseInit?.headers,
+      headers: responseInit.headers,
     },
   );
 }

--- a/src/errors/openai.ts
+++ b/src/errors/openai.ts
@@ -31,9 +31,8 @@ export function toOpenAIError(error: unknown): OpenAIError {
 
 export function toOpenAIErrorResponse(error: unknown, requestId: string): Response {
   const meta = getErrorMeta(error);
-  const upstreamHeaders = meta.response?.headers as Record<string, string> | undefined;
   const responseInit = prepareResponseInit(requestId, {
-    headers: buildRetryHeaders(meta.status, upstreamHeaders),
+    headers: buildRetryHeaders(meta.status, meta.headers as Record<string, string> | undefined),
   });
 
   return toResponse(

--- a/src/errors/openai.ts
+++ b/src/errors/openai.ts
@@ -29,7 +29,11 @@ export function toOpenAIError(error: unknown, requestId?: string): OpenAIError {
   const meta = getErrorMeta(error);
 
   const openAIError = new OpenAIError(
-    maybeMaskMessage(error instanceof Error ? error.message : String(error), meta.status, requestId),
+    maybeMaskMessage(
+      error instanceof Error ? error.message : String(error),
+      meta.status,
+      requestId,
+    ),
     mapType(meta.status),
     meta.statusText,
   );

--- a/src/errors/openai.ts
+++ b/src/errors/openai.ts
@@ -39,9 +39,9 @@ export function toOpenAIErrorResponse(error: unknown, responseInit?: ResponseIni
       meta.code,
     ),
     {
-      ...responseInit,
       status: meta.status,
       statusText: meta.code,
+      headers: responseInit?.headers,
     },
   );
 }

--- a/src/errors/utils.ts
+++ b/src/errors/utils.ts
@@ -27,7 +27,12 @@ export const STATUS_CODE = (status: number) => {
   return status >= 400 && status < 500 ? STATUS_CODES[400] : STATUS_CODES[500];
 };
 
-export type ErrorMeta = { status: number; code: string; message: string };
+export type ErrorMeta = {
+  status: number;
+  code: string;
+  message: string;
+  responseHeaders: Record<string, string> | undefined;
+};
 
 // FUTURE: always return a wrapped GatewayError?
 export function getErrorMeta(error: unknown): ErrorMeta {
@@ -35,20 +40,22 @@ export function getErrorMeta(error: unknown): ErrorMeta {
 
   let status: number;
   let code: string;
+  let responseHeaders: Record<string, string> | undefined;
 
   if (error instanceof GatewayError) {
-    ({ status, code } = error);
+    ({ status, code, responseHeaders } = error);
   } else {
     const normalized = normalizeAiSdkError(error);
     if (normalized) {
-      ({ status, code } = normalized);
+      ({ status, code, responseHeaders } = normalized);
     } else {
       status = 500;
       code = STATUS_CODE(status);
+      responseHeaders = undefined;
     }
   }
 
-  return { status, code, message };
+  return { status, code, message, responseHeaders };
 }
 
 export function maybeMaskMessage(meta: ErrorMeta, requestId?: string): string {

--- a/src/errors/utils.ts
+++ b/src/errors/utils.ts
@@ -21,7 +21,7 @@ export const STATUS_CODES = {
   504: "GATEWAY_TIMEOUT",
 } as const;
 
-export const STATUS_CODE = (status: number) => {
+export const STATUS_TEXT = (status: number) => {
   const label = STATUS_CODES[status as keyof typeof STATUS_CODES];
   if (label) return label;
   return status >= 400 && status < 500 ? STATUS_CODES[400] : STATUS_CODES[500];
@@ -29,40 +29,36 @@ export const STATUS_CODE = (status: number) => {
 
 export type ErrorMeta = {
   status: number;
-  code: string;
-  message: string;
-  headers: HeadersInit | undefined;
+  statusText: string;
+  headers: Record<string, string>;
 };
 
-// FUTURE: always return a wrapped GatewayError?
 export function getErrorMeta(error: unknown): ErrorMeta {
-  const message = error instanceof Error ? error.message : String(error);
-
   let status: number;
-  let code: string;
-  let headers: HeadersInit | undefined;
+  let statusText: string;
+  let headers: Record<string, string> | undefined;
 
   if (error instanceof GatewayError) {
-    ({ status, code, headers } = error);
+    ({ status, statusText, headers } = error);
   } else {
     const normalized = normalizeAiSdkError(error);
     if (normalized) {
-      ({ status, code, headers } = normalized);
+      ({ status, statusText, headers } = normalized);
     } else {
       status = 500;
-      code = STATUS_CODE(status);
-      headers = undefined;
+      statusText = STATUS_TEXT(status);
+      headers = {};
     }
   }
 
-  return { status, code, message, headers };
+  return { status, statusText, headers: headers ?? {} };
 }
 
-export function maybeMaskMessage(meta: ErrorMeta, requestId?: string): string {
+export function maybeMaskMessage(message: string, status: number, requestId?: string): string {
   // FUTURE: consider masking all upstream errors, also 4xx
-  if (!(isProduction() && meta.status >= 500)) {
-    return meta.message;
+  if (!(isProduction() && status >= 500)) {
+    return message;
   }
   // FUTURE: always attach requestId to errors (masked and unmasked)
-  return `${STATUS_CODE(meta.status)} (${requestId ?? "see requestId in response headers"})`;
+  return `${STATUS_TEXT(status)} (${requestId ?? "see requestId in response headers"})`;
 }

--- a/src/errors/utils.ts
+++ b/src/errors/utils.ts
@@ -31,7 +31,7 @@ export type ErrorMeta = {
   status: number;
   code: string;
   message: string;
-  response: ResponseInit | undefined;
+  headers: HeadersInit | undefined;
 };
 
 // FUTURE: always return a wrapped GatewayError?
@@ -40,22 +40,22 @@ export function getErrorMeta(error: unknown): ErrorMeta {
 
   let status: number;
   let code: string;
-  let response: ResponseInit | undefined;
+  let headers: HeadersInit | undefined;
 
   if (error instanceof GatewayError) {
-    ({ status, code, response } = error);
+    ({ status, code, headers } = error);
   } else {
     const normalized = normalizeAiSdkError(error);
     if (normalized) {
-      ({ status, code, response } = normalized);
+      ({ status, code, headers } = normalized);
     } else {
       status = 500;
       code = STATUS_CODE(status);
-      response = undefined;
+      headers = undefined;
     }
   }
 
-  return { status, code, message, response };
+  return { status, code, message, headers };
 }
 
 export function maybeMaskMessage(meta: ErrorMeta, requestId?: string): string {

--- a/src/errors/utils.ts
+++ b/src/errors/utils.ts
@@ -31,7 +31,7 @@ export type ErrorMeta = {
   status: number;
   code: string;
   message: string;
-  responseHeaders: Record<string, string> | undefined;
+  response: ResponseInit | undefined;
 };
 
 // FUTURE: always return a wrapped GatewayError?
@@ -40,22 +40,22 @@ export function getErrorMeta(error: unknown): ErrorMeta {
 
   let status: number;
   let code: string;
-  let responseHeaders: Record<string, string> | undefined;
+  let response: ResponseInit | undefined;
 
   if (error instanceof GatewayError) {
-    ({ status, code, responseHeaders } = error);
+    ({ status, code, response } = error);
   } else {
     const normalized = normalizeAiSdkError(error);
     if (normalized) {
-      ({ status, code, responseHeaders } = normalized);
+      ({ status, code, response } = normalized);
     } else {
       status = 500;
       code = STATUS_CODE(status);
-      responseHeaders = undefined;
+      response = undefined;
     }
   }
 
-  return { status, code, message, responseHeaders };
+  return { status, code, message, response };
 }
 
 export function maybeMaskMessage(meta: ErrorMeta, requestId?: string): string {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -167,7 +167,8 @@ export const winterCgHandler = (
           ? new GatewayError(error ?? ctx.request.signal.reason, 499)
           : error;
         const meta = getErrorMeta(errorPayload);
-        const retryHeaders = buildRetryHeaders(meta.status, meta.responseHeaders);
+        const upstreamHeaders = meta.response?.headers as Record<string, string> | undefined;
+        const retryHeaders = buildRetryHeaders(meta.status, upstreamHeaders);
         const errorResponseInit = mergeResponseInit(
           retryHeaders,
           prepareResponseInit(ctx.requestId),

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -19,13 +19,7 @@ import type {
   OnResponseHookContext,
 } from "./types";
 import { resolveOrCreateRequestId } from "./utils/request";
-import {
-  buildRetryHeaders,
-  filterResponseHeaders,
-  mergeResponseInit,
-  prepareResponseInit,
-  toResponse,
-} from "./utils/response";
+import { buildRetryHeaders, prepareResponseInit, toResponse } from "./utils/response";
 import type { SseFrame } from "./utils/stream";
 
 export const winterCgHandler = (
@@ -121,14 +115,10 @@ export const winterCgHandler = (
         if (!ctx.response) {
           ctx.result = (await run(ctx, parsedConfig)) as typeof ctx.result;
 
-          const responseInit = prepareResponseInit(ctx.requestId);
-          const upstreamInit = ctx.response as ResponseInit | undefined;
-          const filtered = filterResponseHeaders(
-            upstreamInit?.headers as Record<string, string> | undefined,
+          const successResponseInit = prepareResponseInit(
+            ctx.requestId,
+            ctx.response as ResponseInit | undefined,
           );
-          const successResponseInit = filtered
-            ? mergeResponseInit(filtered, responseInit)
-            : responseInit;
           const formatError = ctx.operation === "messages" ? toAnthropicError : toOpenAIError;
           ctx.response = toResponse(ctx.result!, successResponseInit, {
             onDone: finalize,
@@ -168,11 +158,9 @@ export const winterCgHandler = (
           : error;
         const meta = getErrorMeta(errorPayload);
         const upstreamHeaders = meta.response?.headers as Record<string, string> | undefined;
-        const retryHeaders = buildRetryHeaders(meta.status, upstreamHeaders);
-        const errorResponseInit = mergeResponseInit(
-          retryHeaders,
-          prepareResponseInit(ctx.requestId),
-        );
+        const errorResponseInit = prepareResponseInit(ctx.requestId, {
+          headers: buildRetryHeaders(meta.status, upstreamHeaders),
+        });
         if (!(ctx.response instanceof Response)) {
           ctx.response =
             ctx.operation === "messages"

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -18,8 +18,9 @@ import type {
   OnRequestHookContext,
   OnResponseHookContext,
 } from "./types";
+import { buildRetryHeaders } from "./utils/headers";
 import { resolveOrCreateRequestId } from "./utils/request";
-import { buildRetryHeaders, prepareResponseInit, toResponse } from "./utils/response";
+import { prepareResponseInit, toResponse } from "./utils/response";
 import type { SseFrame } from "./utils/stream";
 
 export const winterCgHandler = (

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -2,6 +2,7 @@ import { parseConfig } from "./config";
 import { toAnthropicError, toAnthropicErrorResponse } from "./errors/anthropic";
 import { GatewayError } from "./errors/gateway";
 import { toOpenAIError, toOpenAIErrorResponse } from "./errors/openai";
+import { getErrorMeta } from "./errors/utils";
 import { logger } from "./logger";
 import { getBaggageAttributes } from "./telemetry/baggage";
 import { instrumentFetch } from "./telemetry/fetch";
@@ -78,7 +79,7 @@ export const winterCgHandler = (
         });
 
         const isUpstreamError =
-          reason instanceof GatewayError && reason.code.startsWith("UPSTREAM_");
+          reason instanceof GatewayError && reason.statusText.startsWith("UPSTREAM_");
         span.recordError(reason, realStatus >= 500 || isUpstreamError);
       }
       span.setAttributes({ "http.response.status_code_effective": realStatus });
@@ -114,13 +115,12 @@ export const winterCgHandler = (
         if (!ctx.response) {
           ctx.result = (await run(ctx, parsedConfig)) as typeof ctx.result;
 
-          const formatError = ctx.operation === "messages" ? toAnthropicError : toOpenAIError;
           ctx.response = toResponse(
             ctx.result!,
             prepareResponseInit(ctx.requestId, ctx.response as ResponseInit | undefined),
             {
               onDone: finalize,
-              formatError,
+              toError: ctx.operation === "messages" ? toAnthropicError : toOpenAIError,
             },
           );
         }
@@ -154,9 +154,12 @@ export const winterCgHandler = (
           ? new GatewayError(error ?? ctx.request.signal.reason, 499)
           : error;
         if (!(ctx.response instanceof Response)) {
-          const format =
+          const toErrorResponse =
             ctx.operation === "messages" ? toAnthropicErrorResponse : toOpenAIErrorResponse;
-          ctx.response = format(errorPayload, ctx.requestId);
+          ctx.response = toErrorResponse(
+            errorPayload,
+            prepareResponseInit(ctx.requestId, getErrorMeta(errorPayload)),
+          );
         }
         finalize((ctx.response as Response).status, error);
       }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -116,21 +116,19 @@ export const winterCgHandler = (
         if (!ctx.response) {
           ctx.result = (await run(ctx, parsedConfig)) as typeof ctx.result;
 
-          const successResponseInit = prepareResponseInit(
-            ctx.requestId,
-            ctx.response as ResponseInit | undefined,
-          );
           const formatError = ctx.operation === "messages" ? toAnthropicError : toOpenAIError;
-          ctx.response = toResponse(ctx.result!, successResponseInit, {
-            onDone: finalize,
-            formatError,
-          });
+          ctx.response = toResponse(
+            ctx.result!,
+            prepareResponseInit(ctx.requestId, ctx.response as ResponseInit | undefined),
+            {
+              onDone: finalize,
+              formatError,
+            },
+          );
         }
 
         if (parsedConfig.hooks?.onResponse) {
-          const onResponse = await parsedConfig.hooks.onResponse(
-            ctx as unknown as OnResponseHookContext,
-          );
+          const onResponse = await parsedConfig.hooks.onResponse(ctx as OnResponseHookContext);
           addSpanEvent("hebo.hooks.on_response.completed");
           if (onResponse) {
             ctx.response = onResponse;

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -115,12 +115,14 @@ export const winterCgHandler = (
         if (!ctx.response) {
           ctx.result = (await run(ctx, parsedConfig)) as typeof ctx.result;
 
+          const toError =
+            ctx.operation === "messages" ? toAnthropicError : toOpenAIError;
           ctx.response = toResponse(
             ctx.result!,
             prepareResponseInit(ctx.requestId, ctx.response as ResponseInit | undefined),
             {
               onDone: finalize,
-              toError: ctx.operation === "messages" ? toAnthropicError : toOpenAIError,
+              toError: (error) => toError(error, ctx.requestId),
             },
           );
         }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -2,6 +2,7 @@ import { parseConfig } from "./config";
 import { toAnthropicError, toAnthropicErrorResponse } from "./errors/anthropic";
 import { GatewayError } from "./errors/gateway";
 import { toOpenAIError, toOpenAIErrorResponse } from "./errors/openai";
+import { getErrorMeta } from "./errors/utils";
 import { logger } from "./logger";
 import { getBaggageAttributes } from "./telemetry/baggage";
 import { instrumentFetch } from "./telemetry/fetch";
@@ -18,7 +19,13 @@ import type {
   OnResponseHookContext,
 } from "./types";
 import { resolveOrCreateRequestId } from "./utils/request";
-import { prepareResponseInit, toResponse } from "./utils/response";
+import {
+  buildRetryHeaders,
+  filterResponseHeaders,
+  mergeResponseInit,
+  prepareResponseInit,
+  toResponse,
+} from "./utils/response";
 import type { SseFrame } from "./utils/stream";
 
 export const winterCgHandler = (
@@ -63,7 +70,7 @@ export const winterCgHandler = (
       if (!span.isExisting) {
         // FUTURE add http.server.request.duration
         span.setAttributes(
-          getResponseAttributes(ctx.response!, parsedConfig.telemetry?.signals?.http),
+          getResponseAttributes(ctx.response as Response, parsedConfig.telemetry?.signals?.http),
         );
       }
 
@@ -114,15 +121,25 @@ export const winterCgHandler = (
         if (!ctx.response) {
           ctx.result = (await run(ctx, parsedConfig)) as typeof ctx.result;
 
+          const responseInit = prepareResponseInit(ctx.requestId);
+          const upstreamInit = ctx.response as ResponseInit | undefined;
+          const filtered = filterResponseHeaders(
+            upstreamInit?.headers as Record<string, string> | undefined,
+          );
+          const successResponseInit = filtered
+            ? mergeResponseInit(filtered, responseInit)
+            : responseInit;
           const formatError = ctx.operation === "messages" ? toAnthropicError : toOpenAIError;
-          ctx.response = toResponse(ctx.result!, prepareResponseInit(ctx.requestId), {
+          ctx.response = toResponse(ctx.result!, successResponseInit, {
             onDone: finalize,
             formatError,
           });
         }
 
         if (parsedConfig.hooks?.onResponse) {
-          const onResponse = await parsedConfig.hooks.onResponse(ctx as OnResponseHookContext);
+          const onResponse = await parsedConfig.hooks.onResponse(
+            ctx as unknown as OnResponseHookContext,
+          );
           addSpanEvent("hebo.hooks.on_response.completed");
           if (onResponse) {
             ctx.response = onResponse;
@@ -131,7 +148,7 @@ export const winterCgHandler = (
 
         // FUTURE: this can leak if onResponse removed wrapper from response.body
         if (!(ctx.result instanceof ReadableStream)) {
-          finalize(ctx.response.status);
+          finalize((ctx.response as Response).status);
         }
       } catch (error) {
         if (parsedConfig.hooks?.onError) {
@@ -149,15 +166,22 @@ export const winterCgHandler = (
         const errorPayload = ctx.request.signal.aborted
           ? new GatewayError(error ?? ctx.request.signal.reason, 499)
           : error;
-        const errorResponseInit = prepareResponseInit(ctx.requestId);
-        ctx.response ??=
-          ctx.operation === "messages"
-            ? toAnthropicErrorResponse(errorPayload, errorResponseInit)
-            : toOpenAIErrorResponse(errorPayload, errorResponseInit);
-        finalize(ctx.response.status, error);
+        const meta = getErrorMeta(errorPayload);
+        const retryHeaders = buildRetryHeaders(meta.status, meta.responseHeaders);
+        const errorResponseInit = mergeResponseInit(
+          retryHeaders,
+          prepareResponseInit(ctx.requestId),
+        );
+        if (!(ctx.response instanceof Response)) {
+          ctx.response =
+            ctx.operation === "messages"
+              ? toAnthropicErrorResponse(errorPayload, errorResponseInit)
+              : toOpenAIErrorResponse(errorPayload, errorResponseInit);
+        }
+        finalize((ctx.response as Response).status, error);
       }
     });
 
-    return ctx.response ?? new Response("Internal Server Error", { status: 500 });
+    return (ctx.response as Response) ?? new Response("Internal Server Error", { status: 500 });
   };
 };

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -2,7 +2,6 @@ import { parseConfig } from "./config";
 import { toAnthropicError, toAnthropicErrorResponse } from "./errors/anthropic";
 import { GatewayError } from "./errors/gateway";
 import { toOpenAIError, toOpenAIErrorResponse } from "./errors/openai";
-import { getErrorMeta } from "./errors/utils";
 import { logger } from "./logger";
 import { getBaggageAttributes } from "./telemetry/baggage";
 import { instrumentFetch } from "./telemetry/fetch";
@@ -18,7 +17,6 @@ import type {
   OnRequestHookContext,
   OnResponseHookContext,
 } from "./types";
-import { buildRetryHeaders } from "./utils/headers";
 import { resolveOrCreateRequestId } from "./utils/request";
 import { prepareResponseInit, toResponse } from "./utils/response";
 import type { SseFrame } from "./utils/stream";
@@ -155,16 +153,10 @@ export const winterCgHandler = (
         const errorPayload = ctx.request.signal.aborted
           ? new GatewayError(error ?? ctx.request.signal.reason, 499)
           : error;
-        const meta = getErrorMeta(errorPayload);
-        const upstreamHeaders = meta.response?.headers as Record<string, string> | undefined;
-        const errorResponseInit = prepareResponseInit(ctx.requestId, {
-          headers: buildRetryHeaders(meta.status, upstreamHeaders),
-        });
         if (!(ctx.response instanceof Response)) {
-          ctx.response =
-            ctx.operation === "messages"
-              ? toAnthropicErrorResponse(errorPayload, errorResponseInit)
-              : toOpenAIErrorResponse(errorPayload, errorResponseInit);
+          const format =
+            ctx.operation === "messages" ? toAnthropicErrorResponse : toOpenAIErrorResponse;
+          ctx.response = format(errorPayload, ctx.requestId);
         }
         finalize((ctx.response as Response).status, error);
       }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -115,8 +115,7 @@ export const winterCgHandler = (
         if (!ctx.response) {
           ctx.result = (await run(ctx, parsedConfig)) as typeof ctx.result;
 
-          const toError =
-            ctx.operation === "messages" ? toAnthropicError : toOpenAIError;
+          const toError = ctx.operation === "messages" ? toAnthropicError : toOpenAIError;
           ctx.response = toResponse(
             ctx.result!,
             prepareResponseInit(ctx.requestId, ctx.response as ResponseInit | undefined),

--- a/src/telemetry/gen-ai.ts
+++ b/src/telemetry/gen-ai.ts
@@ -1,6 +1,6 @@
 import { metrics, type Attributes, type Histogram } from "@opentelemetry/api";
 
-import { STATUS_CODE } from "../errors/utils";
+import { STATUS_TEXT } from "../errors/utils";
 import type { GatewayContext, TelemetrySignalLevel } from "../types";
 
 const getMeter = () => metrics.getMeter("@hebo/gateway");
@@ -105,7 +105,7 @@ export const recordRequestDuration = (
   const attrs = getGenAiGeneralAttributes(ctx, signalLevel);
 
   if (status !== 200) {
-    attrs["error.type"] = `${status} ${STATUS_CODE(status).toLowerCase()}`;
+    attrs["error.type"] = `${status} ${STATUS_TEXT(status).toLowerCase()}`;
   }
 
   getRequestDurationHistogram().record(duration / 1000, attrs);

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,8 +91,11 @@ export type GatewayContext = {
     | ResponsesStream;
   /**
    * Response object returned by the handler.
+   *
+   * Handlers may set this to a `ResponseInit` containing upstream response
+   * headers; the lifecycle merges allowlisted headers into the final `Response`.
    */
-  response?: Response;
+  response?: Response | ResponseInit;
   /**
    * Per-request telemetry signal level override.
    * When set (via body parameter or hook), overrides `cfg.telemetry.signals.gen_ai`

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,6 @@ export type GatewayContext = {
     | ResponsesStream;
   /**
    * Response object returned by the handler.
-   *
    * Handlers may set this to a `ResponseInit` containing upstream response
    * headers; the lifecycle merges allowlisted headers into the final `Response`.
    */

--- a/src/utils/headers.test.ts
+++ b/src/utils/headers.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, test } from "bun:test";
 import { RETRY_AFTER_MS_HEADER, buildRetryHeaders, filterResponseHeaders } from "./headers";
 
 describe("filterResponseHeaders", () => {
-  test("returns undefined for undefined input", () => {
-    expect(filterResponseHeaders()).toBeUndefined();
+  test("returns empty object for undefined input", () => {
+    expect(filterResponseHeaders()).toEqual({});
   });
 
-  test("returns undefined when no allowlisted headers present", () => {
-    expect(filterResponseHeaders({ "content-type": "application/json" })).toBeUndefined();
+  test("returns empty object when no allowlisted headers present", () => {
+    expect(filterResponseHeaders({ "content-type": "application/json" })).toEqual({});
   });
 
   test("filters to only allowlisted headers", () => {
@@ -32,15 +32,15 @@ describe("filterResponseHeaders", () => {
 });
 
 describe("buildRetryHeaders", () => {
-  test("returns x-should-retry false for non-retryable status without upstream", () => {
-    expect(buildRetryHeaders(400)).toEqual({ "x-should-retry": "false" });
+  test("returns empty object for non-retryable status without upstream", () => {
+    expect(buildRetryHeaders(400)).toEqual({});
   });
 
-  test("returns x-should-retry false for 422", () => {
-    expect(buildRetryHeaders(422)).toEqual({ "x-should-retry": "false" });
+  test("returns empty object for 422", () => {
+    expect(buildRetryHeaders(422)).toEqual({});
   });
 
-  test("preserves upstream x-should-retry for non-retryable status", () => {
+  test("preserves upstream headers for non-retryable status", () => {
     const upstream = { "x-should-retry": "true" };
     expect(buildRetryHeaders(400, upstream)).toEqual({ "x-should-retry": "true" });
   });
@@ -148,24 +148,6 @@ describe("buildRetryHeaders", () => {
       "retry-after-ms": "500",
       "x-should-retry": "true",
       "x-request-id": "req_123",
-    });
-  });
-
-  test("derives retry-after-ms from retry-after for non-retryable status", () => {
-    const upstream = { "retry-after": "3", "x-should-retry": "true" };
-    expect(buildRetryHeaders(400, upstream)).toEqual({
-      "retry-after": "3",
-      "retry-after-ms": "3000",
-      "x-should-retry": "true",
-    });
-  });
-
-  test("derives retry-after from retry-after-ms for non-retryable status", () => {
-    const upstream = { "retry-after-ms": "2500", "x-should-retry": "true" };
-    expect(buildRetryHeaders(400, upstream)).toEqual({
-      "retry-after": "3",
-      "retry-after-ms": "2500",
-      "x-should-retry": "true",
     });
   });
 });

--- a/src/utils/headers.test.ts
+++ b/src/utils/headers.test.ts
@@ -32,17 +32,17 @@ describe("filterResponseHeaders", () => {
 });
 
 describe("buildRetryHeaders", () => {
-  test("returns empty object for non-retryable status without upstream", () => {
-    expect(buildRetryHeaders(400)).toEqual({});
+  test("sets x-should-retry false for non-retryable status without upstream", () => {
+    expect(buildRetryHeaders(400)).toEqual({ "x-should-retry": "false" });
   });
 
-  test("returns empty object for 422", () => {
-    expect(buildRetryHeaders(422)).toEqual({});
+  test("sets x-should-retry false for 422", () => {
+    expect(buildRetryHeaders(422)).toEqual({ "x-should-retry": "false" });
   });
 
-  test("preserves upstream headers for non-retryable status", () => {
+  test("overrides upstream x-should-retry for non-retryable status", () => {
     const upstream = { "x-should-retry": "true" };
-    expect(buildRetryHeaders(400, upstream)).toEqual({ "x-should-retry": "true" });
+    expect(buildRetryHeaders(400, upstream)).toEqual({ "x-should-retry": "false" });
   });
 
   test("generates fallback retry-after and retry-after-ms for 429 without upstream hints", () => {
@@ -135,6 +135,15 @@ describe("buildRetryHeaders", () => {
     const result = buildRetryHeaders(429, upstream);
     expect(result).toBe(upstream);
     expect(upstream[RETRY_AFTER_MS_HEADER]).toBe("5000");
+  });
+
+  test("ignores HTTP-date Retry-After and falls back to default", () => {
+    const upstream = { "retry-after": "Sat, 19 Apr 2026 05:00:00 GMT" };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after": "Sat, 19 Apr 2026 05:00:00 GMT",
+      "retry-after-ms": "1000",
+      "x-should-retry": "true",
+    });
   });
 
   test("does not filter non-retry headers from upstream", () => {

--- a/src/utils/headers.test.ts
+++ b/src/utils/headers.test.ts
@@ -137,10 +137,31 @@ describe("buildRetryHeaders", () => {
     expect(upstream[RETRY_AFTER_MS_HEADER]).toBe("5000");
   });
 
-  test("ignores HTTP-date Retry-After and falls back to default", () => {
-    const upstream = { "retry-after": "Sat, 19 Apr 2026 05:00:00 GMT" };
+  test("derives consistent values from HTTP-date Retry-After in the future", () => {
+    const futureDate = new Date(Date.now() + 5000).toUTCString();
+    const upstream = { "retry-after": futureDate };
+    const result = buildRetryHeaders(429, upstream);
+    const ms = Number(result["retry-after-ms"]);
+    expect(ms).toBeGreaterThan(0);
+    expect(ms).toBeLessThanOrEqual(5000);
+    expect(result["retry-after"]).toBe(String(Math.ceil(ms / 1000)));
+    expect(result["x-should-retry"]).toBe("true");
+  });
+
+  test("falls back to default for HTTP-date Retry-After in the past", () => {
+    const pastDate = new Date(Date.now() - 5000).toUTCString();
+    const upstream = { "retry-after": pastDate };
     expect(buildRetryHeaders(429, upstream)).toEqual({
-      "retry-after": "Sat, 19 Apr 2026 05:00:00 GMT",
+      "retry-after": "1",
+      "retry-after-ms": "1000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("falls back to default for unparseable Retry-After", () => {
+    const upstream = { "retry-after": "not-a-date-or-number" };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after": "1",
       "retry-after-ms": "1000",
       "x-should-retry": "true",
     });

--- a/src/utils/headers.test.ts
+++ b/src/utils/headers.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildRetryHeaders, filterResponseHeaders } from "./headers";
+
+describe("filterResponseHeaders", () => {
+  test("returns undefined for undefined input", () => {
+    expect(filterResponseHeaders()).toBeUndefined();
+  });
+
+  test("returns undefined when no allowlisted headers present", () => {
+    expect(filterResponseHeaders({ "content-type": "application/json" })).toBeUndefined();
+  });
+
+  test("filters to only allowlisted headers", () => {
+    const upstream = {
+      "retry-after": "2",
+      "retry-after-ms": "500",
+      "x-should-retry": "true",
+      "content-type": "application/json",
+      "x-request-id": "req_123",
+    };
+    expect(filterResponseHeaders(upstream)).toEqual({
+      "retry-after": "2",
+      "retry-after-ms": "500",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("returns only present allowlisted headers", () => {
+    expect(filterResponseHeaders({ "retry-after": "1" })).toEqual({ "retry-after": "1" });
+  });
+});
+
+describe("buildRetryHeaders", () => {
+  test("returns x-should-retry false for non-retryable status without upstream", () => {
+    expect(buildRetryHeaders(400)).toEqual({ "x-should-retry": "false" });
+  });
+
+  test("returns x-should-retry false for 422", () => {
+    expect(buildRetryHeaders(422)).toEqual({ "x-should-retry": "false" });
+  });
+
+  test("preserves upstream x-should-retry for non-retryable status", () => {
+    const upstream = { "x-should-retry": "true" };
+    expect(buildRetryHeaders(400, upstream)).toEqual({ "x-should-retry": "true" });
+  });
+
+  test("generates fallback retry-after and retry-after-ms for 429 without upstream hints", () => {
+    expect(buildRetryHeaders(429)).toEqual({
+      "retry-after": "1",
+      "retry-after-ms": "1000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("generates fallback for 503 without upstream hints", () => {
+    expect(buildRetryHeaders(503)).toEqual({
+      "retry-after": "1",
+      "retry-after-ms": "1000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("generates fallback for 502 without upstream hints", () => {
+    expect(buildRetryHeaders(502)).toEqual({
+      "retry-after": "1",
+      "retry-after-ms": "1000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("generates fallback for 408 without upstream hints", () => {
+    expect(buildRetryHeaders(408)).toEqual({
+      "retry-after": "1",
+      "retry-after-ms": "1000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("generates fallback for 409 without upstream hints", () => {
+    expect(buildRetryHeaders(409)).toEqual({
+      "retry-after": "1",
+      "retry-after-ms": "1000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("forwards upstream retry-after and derives retry-after-ms for retryable status", () => {
+    const upstream = { "retry-after": "5" };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after": "5",
+      "retry-after-ms": "5000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("forwards upstream retry-after-ms and derives retry-after for retryable status", () => {
+    const upstream = { "retry-after-ms": "2000" };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after": "2",
+      "retry-after-ms": "2000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("rounds retry-after up to nearest second", () => {
+    const upstream = { "retry-after-ms": "1500" };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after": "2",
+      "retry-after-ms": "1500",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("forwards all upstream headers when complete for retryable status", () => {
+    const upstream = { "retry-after": "5", "retry-after-ms": "5000", "x-should-retry": "true" };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after": "5",
+      "retry-after-ms": "5000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("respects upstream x-should-retry false for retryable status", () => {
+    const upstream = { "retry-after": "5", "x-should-retry": "false" };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after": "5",
+      "retry-after-ms": "5000",
+      "x-should-retry": "false",
+    });
+  });
+
+  test("filters out non-allowlisted headers from upstream", () => {
+    const upstream = {
+      "retry-after-ms": "500",
+      "x-should-retry": "true",
+      "x-request-id": "req_123",
+    };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after": "1",
+      "retry-after-ms": "500",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("derives retry-after-ms from retry-after for non-retryable status", () => {
+    const upstream = { "retry-after": "3", "x-should-retry": "true" };
+    expect(buildRetryHeaders(400, upstream)).toEqual({
+      "retry-after": "3",
+      "retry-after-ms": "3000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("derives retry-after from retry-after-ms for non-retryable status", () => {
+    const upstream = { "retry-after-ms": "2500", "x-should-retry": "true" };
+    expect(buildRetryHeaders(400, upstream)).toEqual({
+      "retry-after": "3",
+      "retry-after-ms": "2500",
+      "x-should-retry": "true",
+    });
+  });
+});

--- a/src/utils/headers.test.ts
+++ b/src/utils/headers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { buildRetryHeaders, filterResponseHeaders } from "./headers";
+import { RETRY_AFTER_MS_HEADER, buildRetryHeaders, filterResponseHeaders } from "./headers";
 
 describe("filterResponseHeaders", () => {
   test("returns undefined for undefined input", () => {
@@ -130,7 +130,14 @@ describe("buildRetryHeaders", () => {
     });
   });
 
-  test("filters out non-allowlisted headers from upstream", () => {
+  test("mutates upstream record in place", () => {
+    const upstream: Record<string, string> = { "retry-after": "5" };
+    const result = buildRetryHeaders(429, upstream);
+    expect(result).toBe(upstream);
+    expect(upstream[RETRY_AFTER_MS_HEADER]).toBe("5000");
+  });
+
+  test("does not filter non-retry headers from upstream", () => {
     const upstream = {
       "retry-after-ms": "500",
       "x-should-retry": "true",
@@ -140,6 +147,7 @@ describe("buildRetryHeaders", () => {
       "retry-after": "1",
       "retry-after-ms": "500",
       "x-should-retry": "true",
+      "x-request-id": "req_123",
     });
   });
 

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -13,31 +13,8 @@ const RETRYABLE_STATUS_CODES = new Set([408, 409, 429, 500, 502, 503, 504]);
 
 const DEFAULT_RETRY_AFTER_MS = 1000;
 
-type HeaderSource = Request | ResponseInit | undefined;
-
-export const resolveRequestId = (source: HeaderSource): string | undefined => {
-  if (!source) return undefined;
-
-  if (source instanceof Request) {
-    return source.headers.get(REQUEST_ID_HEADER) ?? undefined;
-  }
-
-  const headers = source.headers;
-  if (!headers) return undefined;
-
-  if (headers instanceof Headers) {
-    return headers.get(REQUEST_ID_HEADER) ?? undefined;
-  }
-
-  if (Array.isArray(headers)) {
-    for (const [key, value] of headers) {
-      if (key.toLowerCase() === REQUEST_ID_HEADER) return value;
-    }
-    return undefined;
-  }
-
-  return headers[REQUEST_ID_HEADER];
-};
+export const resolveRequestId = (request: Request): string | undefined =>
+  request.headers.get(REQUEST_ID_HEADER) ?? undefined;
 
 export const filterResponseHeaders = (
   upstream?: Record<string, string>,

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -1,4 +1,17 @@
 export const REQUEST_ID_HEADER = "x-request-id";
+export const RETRY_AFTER_HEADER = "retry-after";
+export const RETRY_AFTER_MS_HEADER = "retry-after-ms";
+export const X_SHOULD_RETRY_HEADER = "x-should-retry";
+
+const RESPONSE_HEADER_ALLOWLIST = [
+  RETRY_AFTER_HEADER,
+  RETRY_AFTER_MS_HEADER,
+  X_SHOULD_RETRY_HEADER,
+] as const;
+
+const RETRYABLE_STATUS_CODES = new Set([408, 409, 429, 500, 502, 503, 504]);
+
+const DEFAULT_RETRY_AFTER_MS = 1000;
 
 type HeaderSource = Request | ResponseInit | undefined;
 
@@ -24,4 +37,60 @@ export const resolveRequestId = (source: HeaderSource): string | undefined => {
   }
 
   return headers[REQUEST_ID_HEADER];
+};
+
+export const filterResponseHeaders = (
+  upstream?: Record<string, string>,
+): Record<string, string> | undefined => {
+  if (!upstream) return undefined;
+
+  let filtered: Record<string, string> | undefined;
+  for (const key of RESPONSE_HEADER_ALLOWLIST) {
+    const value = upstream[key];
+    if (value !== undefined) {
+      filtered ??= {};
+      filtered[key] = value;
+    }
+  }
+  return filtered;
+};
+
+export const buildRetryHeaders = (
+  status: number,
+  upstream?: Record<string, string>,
+): Record<string, string> => {
+  const headers = filterResponseHeaders(upstream) ?? {};
+
+  const shouldRetryHeader = headers[X_SHOULD_RETRY_HEADER];
+  const hasRetryAfter = headers[RETRY_AFTER_HEADER] !== undefined;
+  const hasRetryAfterMs = headers[RETRY_AFTER_MS_HEADER] !== undefined;
+
+  if (!RETRYABLE_STATUS_CODES.has(status)) {
+    if (shouldRetryHeader === undefined) {
+      headers[X_SHOULD_RETRY_HEADER] = "false";
+    }
+    if (hasRetryAfterMs && !hasRetryAfter) {
+      headers[RETRY_AFTER_HEADER] = String(
+        Math.ceil(Number(headers[RETRY_AFTER_MS_HEADER]) / 1000),
+      );
+    }
+    if (hasRetryAfter && !hasRetryAfterMs) {
+      headers[RETRY_AFTER_MS_HEADER] = String(Number(headers[RETRY_AFTER_HEADER]) * 1000);
+    }
+    return headers;
+  }
+
+  if (!hasRetryAfter && !hasRetryAfterMs) {
+    headers[RETRY_AFTER_MS_HEADER] = String(DEFAULT_RETRY_AFTER_MS);
+    headers[RETRY_AFTER_HEADER] = String(Math.ceil(DEFAULT_RETRY_AFTER_MS / 1000));
+  } else if (hasRetryAfterMs && !hasRetryAfter) {
+    headers[RETRY_AFTER_HEADER] = String(Math.ceil(Number(headers[RETRY_AFTER_MS_HEADER]) / 1000));
+  } else if (hasRetryAfter && !hasRetryAfterMs) {
+    headers[RETRY_AFTER_MS_HEADER] = String(Number(headers[RETRY_AFTER_HEADER]) * 1000);
+  }
+
+  if (shouldRetryHeader === undefined) {
+    headers[X_SHOULD_RETRY_HEADER] = "true";
+  }
+  return headers;
 };

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -60,37 +60,24 @@ export const buildRetryHeaders = (
   upstream?: Record<string, string>,
 ): Record<string, string> => {
   const headers = filterResponseHeaders(upstream) ?? {};
+  const retryable = RETRYABLE_STATUS_CODES.has(status);
 
-  const shouldRetryHeader = headers[X_SHOULD_RETRY_HEADER];
-  const hasRetryAfter = headers[RETRY_AFTER_HEADER] !== undefined;
-  const hasRetryAfterMs = headers[RETRY_AFTER_MS_HEADER] !== undefined;
+  const retryAfterMs =
+    headers[RETRY_AFTER_MS_HEADER] ??
+    (headers[RETRY_AFTER_HEADER]
+      ? String(Number(headers[RETRY_AFTER_HEADER]) * 1000)
+      : retryable
+        ? String(DEFAULT_RETRY_AFTER_MS)
+        : undefined);
 
-  if (!RETRYABLE_STATUS_CODES.has(status)) {
-    if (shouldRetryHeader === undefined) {
-      headers[X_SHOULD_RETRY_HEADER] = "false";
-    }
-    if (hasRetryAfterMs && !hasRetryAfter) {
-      headers[RETRY_AFTER_HEADER] = String(
-        Math.ceil(Number(headers[RETRY_AFTER_MS_HEADER]) / 1000),
-      );
-    }
-    if (hasRetryAfter && !hasRetryAfterMs) {
-      headers[RETRY_AFTER_MS_HEADER] = String(Number(headers[RETRY_AFTER_HEADER]) * 1000);
-    }
-    return headers;
-  }
+  const retryAfter =
+    headers[RETRY_AFTER_HEADER] ??
+    (retryAfterMs ? String(Math.ceil(Number(retryAfterMs) / 1000)) : undefined);
 
-  if (!hasRetryAfter && !hasRetryAfterMs) {
-    headers[RETRY_AFTER_MS_HEADER] = String(DEFAULT_RETRY_AFTER_MS);
-    headers[RETRY_AFTER_HEADER] = String(Math.ceil(DEFAULT_RETRY_AFTER_MS / 1000));
-  } else if (hasRetryAfterMs && !hasRetryAfter) {
-    headers[RETRY_AFTER_HEADER] = String(Math.ceil(Number(headers[RETRY_AFTER_MS_HEADER]) / 1000));
-  } else if (hasRetryAfter && !hasRetryAfterMs) {
-    headers[RETRY_AFTER_MS_HEADER] = String(Number(headers[RETRY_AFTER_HEADER]) * 1000);
-  }
+  if (retryAfterMs) headers[RETRY_AFTER_MS_HEADER] = retryAfterMs;
+  if (retryAfter) headers[RETRY_AFTER_HEADER] = retryAfter;
 
-  if (shouldRetryHeader === undefined) {
-    headers[X_SHOULD_RETRY_HEADER] = "true";
-  }
+  headers[X_SHOULD_RETRY_HEADER] ??= retryable ? "true" : "false";
+
   return headers;
 };

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -42,7 +42,7 @@ function getHeader(headers: HeadersInit, key: string): string | undefined {
 export const filterResponseHeaders = (upstream?: HeadersInit): Record<string, string> => {
   if (!upstream) return {};
 
-  let filtered: Record<string, string> = {};
+  const filtered: Record<string, string> = {};
   for (const key of RESPONSE_HEADER_ALLOWLIST) {
     const value = getHeader(upstream, key);
     if (value !== undefined) {
@@ -57,26 +57,27 @@ export const buildRetryHeaders = (
   upstream: Record<string, string> = {},
 ): Record<string, string> => {
   const retryable = RETRYABLE_STATUS_CODES.has(status);
-  if (!retryable) return upstream;
+
+  if (!retryable) {
+    upstream[X_SHOULD_RETRY_HEADER] = "false";
+    return upstream;
+  }
 
   const upstreamMs = upstream[RETRY_AFTER_MS_HEADER];
   const upstreamSec = upstream[RETRY_AFTER_HEADER];
+  const upstreamSecNum = upstreamSec === undefined ? NaN : Number(upstreamSec);
 
   const retryAfterMs =
     upstreamMs ??
-    (upstreamSec
-      ? String(Number(upstreamSec) * 1000)
-      : retryable
-        ? String(DEFAULT_RETRY_AFTER_MS)
-        : undefined);
+    (Number.isFinite(upstreamSecNum)
+      ? String(upstreamSecNum * 1000)
+      : String(DEFAULT_RETRY_AFTER_MS));
 
-  const retryAfter =
-    upstreamSec ?? (retryAfterMs ? String(Math.ceil(Number(retryAfterMs) / 1000)) : undefined);
+  const retryAfter = upstreamSec ?? String(Math.ceil(Number(retryAfterMs) / 1000));
 
-  if (retryAfterMs) upstream[RETRY_AFTER_MS_HEADER] = retryAfterMs;
-  if (retryAfter) upstream[RETRY_AFTER_HEADER] = retryAfter;
-
-  upstream[X_SHOULD_RETRY_HEADER] ??= retryable ? "true" : "false";
+  upstream[RETRY_AFTER_MS_HEADER] = retryAfterMs;
+  upstream[RETRY_AFTER_HEADER] = retryAfter;
+  upstream[X_SHOULD_RETRY_HEADER] ??= "true";
 
   return upstream;
 };

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -52,6 +52,16 @@ export const filterResponseHeaders = (upstream?: HeadersInit): Record<string, st
   return filtered;
 };
 
+function deriveRetryAfterMs(retryAfter: string | undefined): number | undefined {
+  if (retryAfter === undefined) return undefined;
+  const num = Number(retryAfter);
+  if (Number.isFinite(num)) return num * 1000;
+  const dateMs = Date.parse(retryAfter);
+  if (!Number.isFinite(dateMs)) return undefined;
+  const deltaMs = dateMs - Date.now();
+  return deltaMs > 0 ? deltaMs : undefined;
+}
+
 export const buildRetryHeaders = (
   status: number,
   upstream: Record<string, string> = {},
@@ -65,15 +75,11 @@ export const buildRetryHeaders = (
 
   const upstreamMs = upstream[RETRY_AFTER_MS_HEADER];
   const upstreamSec = upstream[RETRY_AFTER_HEADER];
-  const upstreamSecNum = upstreamSec === undefined ? NaN : Number(upstreamSec);
 
-  const retryAfterMs =
-    upstreamMs ??
-    (Number.isFinite(upstreamSecNum)
-      ? String(upstreamSecNum * 1000)
-      : String(DEFAULT_RETRY_AFTER_MS));
+  const derivedMs = deriveRetryAfterMs(upstreamSec);
 
-  const retryAfter = upstreamSec ?? String(Math.ceil(Number(retryAfterMs) / 1000));
+  const retryAfterMs = upstreamMs ?? (derivedMs !== undefined ? String(derivedMs) : String(DEFAULT_RETRY_AFTER_MS));
+  const retryAfter = String(Math.ceil(Number(retryAfterMs) / 1000));
 
   upstream[RETRY_AFTER_MS_HEADER] = retryAfterMs;
   upstream[RETRY_AFTER_HEADER] = retryAfter;

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -13,19 +13,39 @@ const RETRYABLE_STATUS_CODES = new Set([408, 409, 429, 500, 502, 503, 504]);
 
 const DEFAULT_RETRY_AFTER_MS = 1000;
 
-export const resolveRequestId = (request: Request): string | undefined =>
-  request.headers.get(REQUEST_ID_HEADER) ?? undefined;
+type HeaderSource = Request | ResponseInit | undefined;
 
-export const filterResponseHeaders = (
-  upstream?: Record<string, string>,
-): Record<string, string> | undefined => {
-  if (!upstream) return undefined;
+export const resolveRequestId = (source: HeaderSource): string | undefined => {
+  if (!source) return undefined;
+  if (source instanceof Request) {
+    return source.headers.get(REQUEST_ID_HEADER) ?? undefined;
+  }
+  if (!source.headers) return undefined;
+  return getHeader(source.headers, REQUEST_ID_HEADER);
+};
 
-  let filtered: Record<string, string> | undefined;
+function getHeader(headers: HeadersInit, key: string): string | undefined {
+  if (headers instanceof Headers) {
+    return headers.get(key) ?? undefined;
+  }
+  if (Array.isArray(headers)) {
+    for (const [k, v] of headers) {
+      if (k.toLowerCase() === key.toLowerCase()) {
+        return v;
+      }
+    }
+    return undefined;
+  }
+  return headers[key] ?? headers[key.toLowerCase()];
+}
+
+export const filterResponseHeaders = (upstream?: HeadersInit): Record<string, string> => {
+  if (!upstream) return {};
+
+  let filtered: Record<string, string> = {};
   for (const key of RESPONSE_HEADER_ALLOWLIST) {
-    const value = upstream[key];
+    const value = getHeader(upstream, key);
     if (value !== undefined) {
-      filtered ??= {};
       filtered[key] = value;
     }
   }
@@ -34,13 +54,13 @@ export const filterResponseHeaders = (
 
 export const buildRetryHeaders = (
   status: number,
-  upstream?: Record<string, string>,
+  upstream: Record<string, string> = {},
 ): Record<string, string> => {
-  const headers = upstream ?? {};
   const retryable = RETRYABLE_STATUS_CODES.has(status);
+  if (!retryable) return upstream;
 
-  const upstreamMs = headers[RETRY_AFTER_MS_HEADER];
-  const upstreamSec = headers[RETRY_AFTER_HEADER];
+  const upstreamMs = upstream[RETRY_AFTER_MS_HEADER];
+  const upstreamSec = upstream[RETRY_AFTER_HEADER];
 
   const retryAfterMs =
     upstreamMs ??
@@ -53,10 +73,10 @@ export const buildRetryHeaders = (
   const retryAfter =
     upstreamSec ?? (retryAfterMs ? String(Math.ceil(Number(retryAfterMs) / 1000)) : undefined);
 
-  if (retryAfterMs) headers[RETRY_AFTER_MS_HEADER] = retryAfterMs;
-  if (retryAfter) headers[RETRY_AFTER_HEADER] = retryAfter;
+  if (retryAfterMs) upstream[RETRY_AFTER_MS_HEADER] = retryAfterMs;
+  if (retryAfter) upstream[RETRY_AFTER_HEADER] = retryAfter;
 
-  headers[X_SHOULD_RETRY_HEADER] ??= retryable ? "true" : "false";
+  upstream[X_SHOULD_RETRY_HEADER] ??= retryable ? "true" : "false";
 
-  return headers;
+  return upstream;
 };

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -36,20 +36,22 @@ export const buildRetryHeaders = (
   status: number,
   upstream?: Record<string, string>,
 ): Record<string, string> => {
-  const headers = filterResponseHeaders(upstream) ?? {};
+  const headers = upstream ?? {};
   const retryable = RETRYABLE_STATUS_CODES.has(status);
 
+  const upstreamMs = headers[RETRY_AFTER_MS_HEADER];
+  const upstreamSec = headers[RETRY_AFTER_HEADER];
+
   const retryAfterMs =
-    headers[RETRY_AFTER_MS_HEADER] ??
-    (headers[RETRY_AFTER_HEADER]
-      ? String(Number(headers[RETRY_AFTER_HEADER]) * 1000)
+    upstreamMs ??
+    (upstreamSec
+      ? String(Number(upstreamSec) * 1000)
       : retryable
         ? String(DEFAULT_RETRY_AFTER_MS)
         : undefined);
 
   const retryAfter =
-    headers[RETRY_AFTER_HEADER] ??
-    (retryAfterMs ? String(Math.ceil(Number(retryAfterMs) / 1000)) : undefined);
+    upstreamSec ?? (retryAfterMs ? String(Math.ceil(Number(retryAfterMs) / 1000)) : undefined);
 
   if (retryAfterMs) headers[RETRY_AFTER_MS_HEADER] = retryAfterMs;
   if (retryAfter) headers[RETRY_AFTER_HEADER] = retryAfter;

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -55,7 +55,7 @@ export const filterResponseHeaders = (upstream?: HeadersInit): Record<string, st
 function deriveRetryAfterMs(retryAfter: string | undefined): number | undefined {
   if (retryAfter === undefined) return undefined;
   const num = Number(retryAfter);
-  if (Number.isFinite(num)) return num * 1000;
+  if (Number.isFinite(num) && num > 0) return num * 1000;
   const dateMs = Date.parse(retryAfter);
   if (!Number.isFinite(dateMs)) return undefined;
   const deltaMs = dateMs - Date.now();
@@ -66,23 +66,17 @@ export const buildRetryHeaders = (
   status: number,
   upstream: Record<string, string> = {},
 ): Record<string, string> => {
-  const retryable = RETRYABLE_STATUS_CODES.has(status);
-
-  if (!retryable) {
+  if (!RETRYABLE_STATUS_CODES.has(status)) {
     upstream[X_SHOULD_RETRY_HEADER] = "false";
     return upstream;
   }
 
-  const upstreamMs = upstream[RETRY_AFTER_MS_HEADER];
-  const upstreamSec = upstream[RETRY_AFTER_HEADER];
-
-  const derivedMs = deriveRetryAfterMs(upstreamSec);
-
-  const retryAfterMs = upstreamMs ?? (derivedMs !== undefined ? String(derivedMs) : String(DEFAULT_RETRY_AFTER_MS));
-  const retryAfter = String(Math.ceil(Number(retryAfterMs) / 1000));
-
-  upstream[RETRY_AFTER_MS_HEADER] = retryAfterMs;
-  upstream[RETRY_AFTER_HEADER] = retryAfter;
+  upstream[RETRY_AFTER_MS_HEADER] ??= String(
+    deriveRetryAfterMs(upstream[RETRY_AFTER_HEADER]) ?? DEFAULT_RETRY_AFTER_MS,
+  );
+  upstream[RETRY_AFTER_HEADER] = String(
+    Math.ceil((Number(upstream[RETRY_AFTER_MS_HEADER]) || DEFAULT_RETRY_AFTER_MS) / 1000),
+  );
   upstream[X_SHOULD_RETRY_HEADER] ??= "true";
 
   return upstream;

--- a/src/utils/response.test.ts
+++ b/src/utils/response.test.ts
@@ -49,4 +49,22 @@ describe("prepareResponseInit", () => {
       headers: { "x-request-id": "req_4" },
     });
   });
+
+  test("accepts Headers instance as upstream headers", () => {
+    const upstream: ResponseInit = {
+      headers: new Headers({ "retry-after-ms": "1500" }),
+    };
+    expect(prepareResponseInit("req_5", upstream)).toEqual({
+      headers: { "retry-after-ms": "1500", "x-request-id": "req_5" },
+    });
+  });
+
+  test("x-request-id argument takes precedence over upstream", () => {
+    const upstream: ResponseInit = {
+      headers: { "x-request-id": "from_upstream" },
+    };
+    expect(prepareResponseInit("req_6", upstream)).toEqual({
+      headers: { "x-request-id": "req_6" },
+    });
+  });
 });

--- a/src/utils/response.test.ts
+++ b/src/utils/response.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  buildRetryHeaders,
-  filterResponseHeaders,
-  prepareResponseInit,
-  toResponse,
-} from "./response";
+import { prepareResponseInit, toResponse } from "./response";
 
 describe("toResponse", () => {
   test("serializes JSON objects", async () => {
@@ -13,115 +8,6 @@ describe("toResponse", () => {
 
     expect(await response.text()).toBe('{"hello":"world"}');
     expect(response.headers.get("content-type")).toBe("application/json");
-  });
-});
-
-describe("filterResponseHeaders", () => {
-  test("returns undefined for undefined input", () => {
-    expect(filterResponseHeaders()).toBeUndefined();
-  });
-
-  test("returns undefined when no allowlisted headers present", () => {
-    expect(filterResponseHeaders({ "content-type": "application/json" })).toBeUndefined();
-  });
-
-  test("filters to only allowlisted headers", () => {
-    const upstream = {
-      "retry-after": "2",
-      "retry-after-ms": "500",
-      "x-should-retry": "true",
-      "content-type": "application/json",
-      "x-request-id": "req_123",
-    };
-    expect(filterResponseHeaders(upstream)).toEqual({
-      "retry-after": "2",
-      "retry-after-ms": "500",
-      "x-should-retry": "true",
-    });
-  });
-
-  test("returns only present allowlisted headers", () => {
-    expect(filterResponseHeaders({ "retry-after": "1" })).toEqual({ "retry-after": "1" });
-  });
-});
-
-describe("buildRetryHeaders", () => {
-  test("returns x-should-retry false for non-retryable status without upstream", () => {
-    expect(buildRetryHeaders(400)).toEqual({ "x-should-retry": "false" });
-  });
-
-  test("returns x-should-retry false for 422", () => {
-    expect(buildRetryHeaders(422)).toEqual({ "x-should-retry": "false" });
-  });
-
-  test("preserves upstream x-should-retry for non-retryable status", () => {
-    const upstream = { "x-should-retry": "true" };
-    expect(buildRetryHeaders(400, upstream)).toEqual({ "x-should-retry": "true" });
-  });
-
-  test("generates fallback for 429 without upstream hints", () => {
-    expect(buildRetryHeaders(429)).toEqual({ "retry-after-ms": "1000", "x-should-retry": "true" });
-  });
-
-  test("generates fallback for 503 without upstream hints", () => {
-    expect(buildRetryHeaders(503)).toEqual({ "retry-after-ms": "1000", "x-should-retry": "true" });
-  });
-
-  test("generates fallback for 502 without upstream hints", () => {
-    expect(buildRetryHeaders(502)).toEqual({ "retry-after-ms": "1000", "x-should-retry": "true" });
-  });
-
-  test("generates fallback for 408 without upstream hints", () => {
-    expect(buildRetryHeaders(408)).toEqual({ "retry-after-ms": "1000", "x-should-retry": "true" });
-  });
-
-  test("generates fallback for 409 without upstream hints", () => {
-    expect(buildRetryHeaders(409)).toEqual({ "retry-after-ms": "1000", "x-should-retry": "true" });
-  });
-
-  test("forwards upstream retry-after and adds x-should-retry for retryable status", () => {
-    const upstream = { "retry-after": "5" };
-    expect(buildRetryHeaders(429, upstream)).toEqual({
-      "retry-after": "5",
-      "x-should-retry": "true",
-    });
-  });
-
-  test("forwards upstream retry-after-ms and adds x-should-retry for retryable status", () => {
-    const upstream = { "retry-after-ms": "2000" };
-    expect(buildRetryHeaders(429, upstream)).toEqual({
-      "retry-after-ms": "2000",
-      "x-should-retry": "true",
-    });
-  });
-
-  test("forwards all upstream headers when complete for retryable status", () => {
-    const upstream = { "retry-after": "5", "retry-after-ms": "5000", "x-should-retry": "true" };
-    expect(buildRetryHeaders(429, upstream)).toEqual({
-      "retry-after": "5",
-      "retry-after-ms": "5000",
-      "x-should-retry": "true",
-    });
-  });
-
-  test("respects upstream x-should-retry false for retryable status", () => {
-    const upstream = { "retry-after": "5", "x-should-retry": "false" };
-    expect(buildRetryHeaders(429, upstream)).toEqual({
-      "retry-after": "5",
-      "x-should-retry": "false",
-    });
-  });
-
-  test("filters out non-allowlisted headers from upstream", () => {
-    const upstream = {
-      "retry-after-ms": "500",
-      "x-should-retry": "true",
-      "x-request-id": "req_123",
-    };
-    expect(buildRetryHeaders(429, upstream)).toEqual({
-      "retry-after-ms": "500",
-      "x-should-retry": "true",
-    });
   });
 });
 

--- a/src/utils/response.test.ts
+++ b/src/utils/response.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { buildRetryHeaders, filterResponseHeaders, toResponse } from "./response";
+import {
+  buildRetryHeaders,
+  filterResponseHeaders,
+  prepareResponseInit,
+  toResponse,
+} from "./response";
 
 describe("toResponse", () => {
   test("serializes JSON objects", async () => {
@@ -116,6 +121,46 @@ describe("buildRetryHeaders", () => {
     expect(buildRetryHeaders(429, upstream)).toEqual({
       "retry-after-ms": "500",
       "x-should-retry": "true",
+    });
+  });
+});
+
+describe("prepareResponseInit", () => {
+  test("returns x-request-id header without upstream", () => {
+    expect(prepareResponseInit("req_1")).toEqual({
+      headers: { "x-request-id": "req_1" },
+    });
+  });
+
+  test("merges filtered upstream headers with x-request-id", () => {
+    const upstream: ResponseInit = {
+      headers: {
+        "retry-after": "5",
+        "x-should-retry": "true",
+        "content-type": "application/json",
+      },
+    };
+    expect(prepareResponseInit("req_2", upstream)).toEqual({
+      headers: {
+        "retry-after": "5",
+        "x-should-retry": "true",
+        "x-request-id": "req_2",
+      },
+    });
+  });
+
+  test("ignores upstream with no allowlisted headers", () => {
+    const upstream: ResponseInit = {
+      headers: { "content-type": "application/json" },
+    };
+    expect(prepareResponseInit("req_3", upstream)).toEqual({
+      headers: { "x-request-id": "req_3" },
+    });
+  });
+
+  test("handles empty upstream", () => {
+    expect(prepareResponseInit("req_4", {})).toEqual({
+      headers: { "x-request-id": "req_4" },
     });
   });
 });

--- a/src/utils/response.test.ts
+++ b/src/utils/response.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { toResponse } from "./response";
+import { buildRetryHeaders, filterResponseHeaders, toResponse } from "./response";
 
 describe("toResponse", () => {
   test("serializes JSON objects", async () => {
@@ -8,5 +8,114 @@ describe("toResponse", () => {
 
     expect(await response.text()).toBe('{"hello":"world"}');
     expect(response.headers.get("content-type")).toBe("application/json");
+  });
+});
+
+describe("filterResponseHeaders", () => {
+  test("returns undefined for undefined input", () => {
+    expect(filterResponseHeaders()).toBeUndefined();
+  });
+
+  test("returns undefined when no allowlisted headers present", () => {
+    expect(filterResponseHeaders({ "content-type": "application/json" })).toBeUndefined();
+  });
+
+  test("filters to only allowlisted headers", () => {
+    const upstream = {
+      "retry-after": "2",
+      "retry-after-ms": "500",
+      "x-should-retry": "true",
+      "content-type": "application/json",
+      "x-request-id": "req_123",
+    };
+    expect(filterResponseHeaders(upstream)).toEqual({
+      "retry-after": "2",
+      "retry-after-ms": "500",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("returns only present allowlisted headers", () => {
+    expect(filterResponseHeaders({ "retry-after": "1" })).toEqual({ "retry-after": "1" });
+  });
+});
+
+describe("buildRetryHeaders", () => {
+  test("returns x-should-retry false for non-retryable status without upstream", () => {
+    expect(buildRetryHeaders(400)).toEqual({ "x-should-retry": "false" });
+  });
+
+  test("returns x-should-retry false for 422", () => {
+    expect(buildRetryHeaders(422)).toEqual({ "x-should-retry": "false" });
+  });
+
+  test("preserves upstream x-should-retry for non-retryable status", () => {
+    const upstream = { "x-should-retry": "true" };
+    expect(buildRetryHeaders(400, upstream)).toEqual({ "x-should-retry": "true" });
+  });
+
+  test("generates fallback for 429 without upstream hints", () => {
+    expect(buildRetryHeaders(429)).toEqual({ "retry-after-ms": "1000", "x-should-retry": "true" });
+  });
+
+  test("generates fallback for 503 without upstream hints", () => {
+    expect(buildRetryHeaders(503)).toEqual({ "retry-after-ms": "1000", "x-should-retry": "true" });
+  });
+
+  test("generates fallback for 502 without upstream hints", () => {
+    expect(buildRetryHeaders(502)).toEqual({ "retry-after-ms": "1000", "x-should-retry": "true" });
+  });
+
+  test("generates fallback for 408 without upstream hints", () => {
+    expect(buildRetryHeaders(408)).toEqual({ "retry-after-ms": "1000", "x-should-retry": "true" });
+  });
+
+  test("generates fallback for 409 without upstream hints", () => {
+    expect(buildRetryHeaders(409)).toEqual({ "retry-after-ms": "1000", "x-should-retry": "true" });
+  });
+
+  test("forwards upstream retry-after and adds x-should-retry for retryable status", () => {
+    const upstream = { "retry-after": "5" };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after": "5",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("forwards upstream retry-after-ms and adds x-should-retry for retryable status", () => {
+    const upstream = { "retry-after-ms": "2000" };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after-ms": "2000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("forwards all upstream headers when complete for retryable status", () => {
+    const upstream = { "retry-after": "5", "retry-after-ms": "5000", "x-should-retry": "true" };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after": "5",
+      "retry-after-ms": "5000",
+      "x-should-retry": "true",
+    });
+  });
+
+  test("respects upstream x-should-retry false for retryable status", () => {
+    const upstream = { "retry-after": "5", "x-should-retry": "false" };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after": "5",
+      "x-should-retry": "false",
+    });
+  });
+
+  test("filters out non-allowlisted headers from upstream", () => {
+    const upstream = {
+      "retry-after-ms": "500",
+      "x-should-retry": "true",
+      "x-request-id": "req_123",
+    };
+    expect(buildRetryHeaders(429, upstream)).toEqual({
+      "retry-after-ms": "500",
+      "x-should-retry": "true",
+    });
   });
 });

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,28 +1,30 @@
-import { REQUEST_ID_HEADER, filterResponseHeaders } from "./headers";
+import { buildRetryHeaders, filterResponseHeaders, REQUEST_ID_HEADER } from "./headers";
 import type { SseFrame } from "./stream";
 import { toSseStream } from "./stream";
 
 const TEXT_ENCODER = new TextEncoder();
 
 export const prepareResponseInit = (requestId: string, upstream?: ResponseInit): ResponseInit => {
-  const filtered = filterResponseHeaders(upstream?.headers as Record<string, string> | undefined);
-  const headers: Record<string, string> = filtered ?? {};
-  headers[REQUEST_ID_HEADER] = requestId;
-  return { headers };
+  const init = upstream ?? {};
+  init.headers = filterResponseHeaders(upstream?.headers);
+  if (init.status && init.status >= 400)
+    init.headers = buildRetryHeaders(init.status, init.headers);
+  init.headers[REQUEST_ID_HEADER] = requestId;
+  return init;
 };
 
 export const mergeResponseInit = (
-  defaultHeaders: HeadersInit,
+  headers: Record<string, string>,
   responseInit?: ResponseInit,
 ): ResponseInit => {
-  const headers = new Headers(defaultHeaders);
+  if (!responseInit) return { headers };
+
   const override = responseInit?.headers;
   if (override) {
     new Headers(override).forEach((value, key) => {
-      headers.set(key, value);
+      headers[key] = value;
     });
   }
-  if (!responseInit) return { headers };
 
   return {
     status: responseInit.status,
@@ -36,7 +38,7 @@ export const toResponse = (
   responseInit?: ResponseInit,
   streamOptions?: {
     onDone?: (status: number, reason?: unknown) => void;
-    formatError?: (error: unknown) => unknown;
+    toError?: (error: unknown) => unknown;
   },
 ): Response => {
   let body: BodyInit;

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -4,6 +4,58 @@ import { toSseStream } from "./stream";
 
 const TEXT_ENCODER = new TextEncoder();
 
+const RESPONSE_HEADER_ALLOWLIST = ["retry-after", "retry-after-ms", "x-should-retry"] as const;
+
+const RETRYABLE_STATUS_CODES = new Set([408, 409, 429, 502, 503]);
+
+const DEFAULT_RETRY_AFTER_MS = "1000";
+
+export const filterResponseHeaders = (
+  upstream?: Record<string, string>,
+): Record<string, string> | undefined => {
+  if (!upstream) return undefined;
+
+  let filtered: Record<string, string> | undefined;
+  for (const key of RESPONSE_HEADER_ALLOWLIST) {
+    const value = upstream[key];
+    if (value !== undefined) {
+      filtered ??= {};
+      filtered[key] = value;
+    }
+  }
+  return filtered;
+};
+
+export const buildRetryHeaders = (
+  status: number,
+  upstream?: Record<string, string>,
+): Record<string, string> => {
+  const filtered = filterResponseHeaders(upstream);
+
+  if (!RETRYABLE_STATUS_CODES.has(status)) {
+    if (filtered?.["x-should-retry"] !== undefined) return filtered;
+    const result: Record<string, string> = { "x-should-retry": "false" };
+    if (filtered) {
+      for (const key in filtered) result[key] = filtered[key]!;
+    }
+    return result;
+  }
+
+  const hasTimingHint =
+    filtered?.["retry-after"] !== undefined || filtered?.["retry-after-ms"] !== undefined;
+  const shouldRetry = filtered?.["x-should-retry"];
+
+  if (filtered && hasTimingHint && shouldRetry !== undefined) return filtered;
+
+  const result: Record<string, string> = {};
+  if (filtered) {
+    for (const key in filtered) result[key] = filtered[key]!;
+  }
+  if (!hasTimingHint) result["retry-after-ms"] = DEFAULT_RETRY_AFTER_MS;
+  if (shouldRetry === undefined) result["x-should-retry"] = "true";
+  return result;
+};
+
 export const prepareResponseInit = (requestId: string): ResponseInit => ({
   headers: { [REQUEST_ID_HEADER]: requestId },
 });

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -53,9 +53,17 @@ export const buildRetryHeaders = (
   return headers;
 };
 
-export const prepareResponseInit = (requestId: string): ResponseInit => ({
-  headers: { [REQUEST_ID_HEADER]: requestId },
-});
+export const prepareResponseInit = (
+  requestId: string,
+  upstream?: ResponseInit,
+): ResponseInit => {
+  const filtered = filterResponseHeaders(
+    upstream?.headers as Record<string, string> | undefined,
+  );
+  return {
+    headers: { ...filtered, [REQUEST_ID_HEADER]: requestId },
+  };
+};
 
 export const mergeResponseInit = (
   defaultHeaders: HeadersInit,

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -6,7 +6,7 @@ const TEXT_ENCODER = new TextEncoder();
 
 const RESPONSE_HEADER_ALLOWLIST = ["retry-after", "retry-after-ms", "x-should-retry"] as const;
 
-const RETRYABLE_STATUS_CODES = new Set([408, 409, 429, 502, 503]);
+const RETRYABLE_STATUS_CODES = new Set([408, 409, 429, 500, 502, 503, 504]);
 
 const DEFAULT_RETRY_AFTER_MS = "1000";
 
@@ -30,30 +30,27 @@ export const buildRetryHeaders = (
   status: number,
   upstream?: Record<string, string>,
 ): Record<string, string> => {
-  const filtered = filterResponseHeaders(upstream);
+  const headers = filterResponseHeaders(upstream) ?? {};
+
+  const shouldRetryHeader = headers["x-should-retry"];
+  const hasTimingHint =
+    headers["retry-after"] !== undefined || headers["retry-after-ms"] !== undefined;
 
   if (!RETRYABLE_STATUS_CODES.has(status)) {
-    if (filtered?.["x-should-retry"] !== undefined) return filtered;
-    const result: Record<string, string> = { "x-should-retry": "false" };
-    if (filtered) {
-      for (const key in filtered) result[key] = filtered[key]!;
+    if (shouldRetryHeader === undefined) {
+      headers["x-should-retry"] = "false";
     }
-    return result;
+    return headers;
   }
 
-  const hasTimingHint =
-    filtered?.["retry-after"] !== undefined || filtered?.["retry-after-ms"] !== undefined;
-  const shouldRetry = filtered?.["x-should-retry"];
-
-  if (filtered && hasTimingHint && shouldRetry !== undefined) return filtered;
-
-  const result: Record<string, string> = {};
-  if (filtered) {
-    for (const key in filtered) result[key] = filtered[key]!;
+  if (!hasTimingHint) {
+    headers["retry-after-ms"] = DEFAULT_RETRY_AFTER_MS;
   }
-  if (!hasTimingHint) result["retry-after-ms"] = DEFAULT_RETRY_AFTER_MS;
-  if (shouldRetry === undefined) result["x-should-retry"] = "true";
-  return result;
+
+  if (shouldRetryHeader === undefined) {
+    headers["x-should-retry"] = "true";
+  }
+  return headers;
 };
 
 export const prepareResponseInit = (requestId: string): ResponseInit => ({

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,68 +1,14 @@
-import { REQUEST_ID_HEADER } from "./headers";
+import { REQUEST_ID_HEADER, filterResponseHeaders } from "./headers";
 import type { SseFrame } from "./stream";
 import { toSseStream } from "./stream";
 
 const TEXT_ENCODER = new TextEncoder();
 
-const RESPONSE_HEADER_ALLOWLIST = ["retry-after", "retry-after-ms", "x-should-retry"] as const;
-
-const RETRYABLE_STATUS_CODES = new Set([408, 409, 429, 500, 502, 503, 504]);
-
-const DEFAULT_RETRY_AFTER_MS = "1000";
-
-export const filterResponseHeaders = (
-  upstream?: Record<string, string>,
-): Record<string, string> | undefined => {
-  if (!upstream) return undefined;
-
-  let filtered: Record<string, string> | undefined;
-  for (const key of RESPONSE_HEADER_ALLOWLIST) {
-    const value = upstream[key];
-    if (value !== undefined) {
-      filtered ??= {};
-      filtered[key] = value;
-    }
-  }
-  return filtered;
-};
-
-export const buildRetryHeaders = (
-  status: number,
-  upstream?: Record<string, string>,
-): Record<string, string> => {
-  const headers = filterResponseHeaders(upstream) ?? {};
-
-  const shouldRetryHeader = headers["x-should-retry"];
-  const hasTimingHint =
-    headers["retry-after"] !== undefined || headers["retry-after-ms"] !== undefined;
-
-  if (!RETRYABLE_STATUS_CODES.has(status)) {
-    if (shouldRetryHeader === undefined) {
-      headers["x-should-retry"] = "false";
-    }
-    return headers;
-  }
-
-  if (!hasTimingHint) {
-    headers["retry-after-ms"] = DEFAULT_RETRY_AFTER_MS;
-  }
-
-  if (shouldRetryHeader === undefined) {
-    headers["x-should-retry"] = "true";
-  }
-  return headers;
-};
-
-export const prepareResponseInit = (
-  requestId: string,
-  upstream?: ResponseInit,
-): ResponseInit => {
-  const filtered = filterResponseHeaders(
-    upstream?.headers as Record<string, string> | undefined,
-  );
-  return {
-    headers: { ...filtered, [REQUEST_ID_HEADER]: requestId },
-  };
+export const prepareResponseInit = (requestId: string, upstream?: ResponseInit): ResponseInit => {
+  const filtered = filterResponseHeaders(upstream?.headers as Record<string, string> | undefined);
+  const headers: Record<string, string> = filtered ?? {};
+  headers[REQUEST_ID_HEADER] = requestId;
+  return { headers };
 };
 
 export const mergeResponseInit = (

--- a/src/utils/stream.test.ts
+++ b/src/utils/stream.test.ts
@@ -74,6 +74,14 @@ describe("stream utils", () => {
             controller.close();
           },
         }),
+        {
+          toError: (e) => ({
+            error: {
+              message: e instanceof Error ? e.message : String(e),
+              type: "server_error",
+            },
+          }),
+        },
       ),
     );
 

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -80,7 +80,7 @@ export function toSseStream(
           controller.enqueue(
             TEXT_ENCODER.encode(serializeSseFrame({ event: value.event, data: error })),
           );
-          done(controller, (error as Record<string, number>)["status"] ?? 500, value.data);
+          done(controller, (error as Record<string, number>)["status"] ?? 502, value.data);
           reader!.cancel(value.data).catch(() => {});
           return;
         }

--- a/src/utils/stream.ts
+++ b/src/utils/stream.ts
@@ -1,5 +1,3 @@
-import { toOpenAIError } from "../errors/openai";
-
 const TEXT_ENCODER = new TextEncoder();
 
 const SSE_DONE_CHUNK = TEXT_ENCODER.encode("data: [DONE]\n\n");
@@ -18,8 +16,8 @@ export function toSseStream(
   src: ReadableStream<SseFrame>,
   options: {
     onDone?: (status: number, reason?: unknown) => void;
+    toError?: (error: unknown) => unknown;
     keepAliveMs?: number;
-    formatError?: (error: unknown) => unknown;
   } = {},
 ): ReadableStream<Uint8Array> {
   const keepAliveMs = options.keepAliveMs ?? SSE_DEFAULT_KEEP_ALIVE_MS;
@@ -78,15 +76,11 @@ export function toSseStream(
 
         const value = result.value;
         if (value.event === "error" || value.data instanceof Error) {
-          const error = options.formatError
-            ? options.formatError(value.data)
-            : toOpenAIError(value.data);
+          const error = options.toError?.(value.data) ?? value.data;
           controller.enqueue(
             TEXT_ENCODER.encode(serializeSseFrame({ event: value.event, data: error })),
           );
-          const openAiError = toOpenAIError(value.data);
-          const errorStatus = openAiError?.error.type === "invalid_request_error" ? 422 : 502;
-          done(controller, errorStatus, value.data);
+          done(controller, (error as Record<string, number>)["status"] ?? 500, value.data);
           reader!.cancel(value.data).catch(() => {});
           return;
         }
@@ -95,14 +89,11 @@ export function toSseStream(
         heartbeat(controller);
       } catch (error) {
         try {
-          const errorPayload = options.formatError
-            ? options.formatError(error)
-            : toOpenAIError(error);
           controller.enqueue(
             TEXT_ENCODER.encode(
               serializeSseFrame({
                 event: "error",
-                data: errorPayload,
+                data: options.toError?.(error) ?? error,
               }),
             ),
           );

--- a/test/e2e/chat-completions/chat-completions-claude.test.ts
+++ b/test/e2e/chat-completions/chat-completions-claude.test.ts
@@ -6,7 +6,10 @@ import type { ChatCompletionMessageFunctionToolCall } from "openai/resources/cha
 import { claudeSonnet46 } from "../../../src/models/anthropic";
 import { BEDROCK_ACCESS_KEY_ID, BEDROCK_SECRET_ACCESS_KEY } from "../shared/server";
 import { createBedrockTestServer, type TestServer } from "../shared/server";
-import { CHAT_CALCULATOR_TOOL as CALCULATOR_TOOL, CHAT_WEATHER_TOOL as WEATHER_TOOL } from "../shared/tools";
+import {
+  CHAT_CALCULATOR_TOOL as CALCULATOR_TOOL,
+  CHAT_WEATHER_TOOL as WEATHER_TOOL,
+} from "../shared/tools";
 
 // ---------------------------------------------------------------------------
 // Environment

--- a/test/e2e/chat-completions/chat-completions.test.ts
+++ b/test/e2e/chat-completions/chat-completions.test.ts
@@ -6,7 +6,10 @@ import type { ChatCompletionMessageFunctionToolCall } from "openai/resources/cha
 import { gptOss120b } from "../../../src/models/openai";
 import { BEDROCK_ACCESS_KEY_ID, BEDROCK_SECRET_ACCESS_KEY } from "../shared/server";
 import { createBedrockTestServer, type TestServer } from "../shared/server";
-import { CHAT_CALCULATOR_TOOL as CALCULATOR_TOOL, CHAT_WEATHER_TOOL as WEATHER_TOOL } from "../shared/tools";
+import {
+  CHAT_CALCULATOR_TOOL as CALCULATOR_TOOL,
+  CHAT_WEATHER_TOOL as WEATHER_TOOL,
+} from "../shared/tools";
 
 // ---------------------------------------------------------------------------
 // Environment

--- a/test/e2e/messages/messages.test.ts
+++ b/test/e2e/messages/messages.test.ts
@@ -5,7 +5,10 @@ import Anthropic, { APIError } from "@anthropic-ai/sdk";
 import { claudeHaiku45, claudeSonnet4 } from "../../../src/models/anthropic";
 import { BEDROCK_ACCESS_KEY_ID, BEDROCK_SECRET_ACCESS_KEY } from "../shared/server";
 import { createBedrockTestServer, type TestServer } from "../shared/server";
-import { MESSAGE_CALCULATOR_TOOL as CALCULATOR_TOOL, MESSAGE_WEATHER_TOOL as WEATHER_TOOL } from "../shared/tools";
+import {
+  MESSAGE_CALCULATOR_TOOL as CALCULATOR_TOOL,
+  MESSAGE_WEATHER_TOOL as WEATHER_TOOL,
+} from "../shared/tools";
 
 // ---------------------------------------------------------------------------
 // Environment

--- a/test/e2e/responses/responses-claude.test.ts
+++ b/test/e2e/responses/responses-claude.test.ts
@@ -11,7 +11,10 @@ import type {
 import { claudeSonnet46 } from "../../../src/models/anthropic";
 import { BEDROCK_ACCESS_KEY_ID, BEDROCK_SECRET_ACCESS_KEY } from "../shared/server";
 import { createBedrockTestServer, type TestServer } from "../shared/server";
-import { RESPONSE_CALCULATOR_TOOL as CALCULATOR_TOOL, RESPONSE_WEATHER_TOOL as WEATHER_TOOL } from "../shared/tools";
+import {
+  RESPONSE_CALCULATOR_TOOL as CALCULATOR_TOOL,
+  RESPONSE_WEATHER_TOOL as WEATHER_TOOL,
+} from "../shared/tools";
 
 // ---------------------------------------------------------------------------
 // Environment

--- a/test/e2e/responses/responses.test.ts
+++ b/test/e2e/responses/responses.test.ts
@@ -11,7 +11,10 @@ import type {
 import { gptOss120b } from "../../../src/models/openai";
 import { BEDROCK_ACCESS_KEY_ID, BEDROCK_SECRET_ACCESS_KEY } from "../shared/server";
 import { createBedrockTestServer, type TestServer } from "../shared/server";
-import { RESPONSE_CALCULATOR_TOOL as CALCULATOR_TOOL, RESPONSE_WEATHER_TOOL as WEATHER_TOOL } from "../shared/tools";
+import {
+  RESPONSE_CALCULATOR_TOOL as CALCULATOR_TOOL,
+  RESPONSE_WEATHER_TOOL as WEATHER_TOOL,
+} from "../shared/tools";
 
 // ---------------------------------------------------------------------------
 // Environment


### PR DESCRIPTION
Thread upstream retry-related response headers through both error and success paths so SDK consumers (OpenAI, Anthropic, Vercel AI SDK) get server-guided retry behavior instead of blind exponential backoff.

- Overload `ctx.response` with `Response | ResponseInit` (no new context field)
- Add `RESPONSE_HEADER_ALLOWLIST` + `filterResponseHeaders()` (general) and `buildRetryHeaders()` (error-specific) in `response.ts`
- Success path: handlers set `ctx.response = { headers }` as `ResponseInit`; lifecycle filters and merges
- Error path: extract from `APICallError`, unwrap `RetryError`, apply retry defaults
- Generate fallback `retry-after-ms: 1000` for retryable statuses without upstream hints
- Set `x-should-retry: false` for non-retryable errors

Closes #128

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Propagate upstream AI response headers into client responses for non-streaming requests.

* **Improvements**
  * Enhanced retry-header handling and propagation; response preparation now merges allowlisted upstream headers and request IDs.
  * Standardized status-text usage across error reporting and preserved upstream headers when normalizing errors.
  * SSE streaming emits normalized error payloads; context response can be a Response or ResponseInit.

* **Tests**
  * Added coverage for error normalization, header utilities, response preparation, and stream error formatting.

* **Chores**
  * Updated example run instructions and linting exclusions; package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->