### PR TITLE
fix: emit signature_delta from reasoning-delta in streaming messages

### DIFF
--- a/src/endpoints/messages/converters.test.ts
+++ b/src/endpoints/messages/converters.test.ts
@@ -1233,10 +1233,12 @@ describe("Messages Converters", () => {
           controller.enqueue({ type: "reasoning-start", id: "r1" });
           controller.enqueue({ type: "reasoning-delta", id: "r1", text: "Thinking..." });
           controller.enqueue({
-            type: "reasoning-end",
+            type: "reasoning-delta",
             id: "r1",
-            providerMetadata: { unknown: { signature: "sig_xyz" } },
+            text: "",
+            providerMetadata: { anthropic: { signature: "sig_xyz" } },
           });
+          controller.enqueue({ type: "reasoning-end", id: "r1" });
           controller.enqueue({ type: "text-start", id: "t1" });
           controller.enqueue({ type: "text-delta", id: "t1", text: "Answer" });
           controller.enqueue({ type: "text-end", id: "t1" });

--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -614,19 +614,6 @@ export class MessagesTransformStream extends TransformStream<
           }
 
           case "reasoning-delta": {
-            controller.enqueue({
-              event: "content_block_delta",
-              data: {
-                type: "content_block_delta",
-                index: blockIndex,
-                delta: { type: "thinking_delta", thinking: part.text },
-              },
-            });
-            break;
-          }
-
-          case "reasoning-end": {
-            // Emit signature delta if available from provider metadata
             const { signature } = extractReasoningMetadata(part.providerMetadata);
             if (signature) {
               controller.enqueue({
@@ -637,8 +624,20 @@ export class MessagesTransformStream extends TransformStream<
                   delta: { type: "signature_delta", signature },
                 },
               });
+            } else {
+              controller.enqueue({
+                event: "content_block_delta",
+                data: {
+                  type: "content_block_delta",
+                  index: blockIndex,
+                  delta: { type: "thinking_delta", thinking: part.text },
+                },
+              });
             }
+            break;
+          }
 
+          case "reasoning-end": {
             controller.enqueue({
               event: "content_block_stop",
               data: { type: "content_block_stop", index: blockIndex },


### PR DESCRIPTION
Fixes #132

The `@ai-sdk/anthropic` provider delivers the thinking block signature as a `reasoning-delta` event with empty text and the signature in `providerMetadata`, not on `reasoning-end`. The `MessagesTransformStream` was only reading `part.text` from `reasoning-delta`, silently dropping the signature. This caused multi-turn conversations to fail because the Anthropic API rejects unsigned thinking blocks.

Changes:
- Move signature extraction into the `reasoning-delta` handler
- Simplify `reasoning-end` to only emit `content_block_stop`
- Update test to match real provider behavior

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of reasoning metadata during message streaming to properly sequence reasoning events and provider-specific signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->