### PR TITLE
revert: always set span ERROR status for non-200 responses

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -78,9 +78,7 @@ export const winterCgHandler = (
           err: reason ?? ctx.request.signal.reason,
         });
 
-        const isUpstreamError =
-          reason instanceof GatewayError && reason.statusText.startsWith("UPSTREAM_");
-        span.recordError(reason, realStatus >= 500 || isUpstreamError);
+        span.recordError(reason, true);
       }
       span.setAttributes({ "http.response.status_code_effective": realStatus });
 


### PR DESCRIPTION
Reverts the change from PR #127 that only set span ERROR status for 5xx and upstream errors. Consumers need to be able to filter for 4xx spans to detect malfunctioning agents.

Closes #134

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified error recording logic to ensure consistent error reporting across all non-200 status responses, improving reliability and reducing code complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->