### PR TITLE
fix: remove deprecated Groq models

### DIFF
--- a/src/models/meta/presets.ts
+++ b/src/models/meta/presets.ts
@@ -10,7 +10,6 @@ const LLAMA_3_BASE = {
   capabilities: ["attachments", "tool_call", "temperature"] as const,
   context: 128000,
   providers: [
-    "groq",
     "bedrock",
     "vertex",
     "azure",
@@ -24,6 +23,7 @@ export const llama31_8b = presetFor<CanonicalModelId, CatalogModel>()(
     name: "Llama 3.1 8B",
     created: "2024-07-23",
     knowledge: "2023-12",
+    providers: ["groq", ...LLAMA_3_BASE.providers],
   } satisfies CatalogModel,
 );
 
@@ -94,6 +94,7 @@ export const llama33_70b = presetFor<CanonicalModelId, CatalogModel>()(
     name: "Llama 3.3 70B",
     created: "2024-12-06",
     knowledge: "2023-12",
+    providers: ["groq", ...LLAMA_3_BASE.providers],
   } satisfies CatalogModel,
 );
 
@@ -105,7 +106,6 @@ const LLAMA_4_BASE = {
   capabilities: ["attachments", "tool_call", "temperature"] as const,
   context: 1000000,
   providers: [
-    "groq",
     "bedrock",
     "vertex",
     "azure",
@@ -119,6 +119,7 @@ export const llama4Scout = presetFor<CanonicalModelId, CatalogModel>()(
     name: "Llama 4 Scout",
     created: "2025-08-05",
     knowledge: "2024-06",
+    providers: ["groq", ...LLAMA_4_BASE.providers],
   } satisfies CatalogModel,
 );
 

--- a/src/providers/groq/canonical.ts
+++ b/src/providers/groq/canonical.ts
@@ -7,7 +7,6 @@ const MAPPING = {
   "meta/llama-3.1-8b": "llama-3.1-8b-instant",
   "meta/llama-3.3-70b": "llama-3.3-70b-versatile",
   "meta/llama-4-scout": "meta-llama/llama-4-scout-17b-16e-instruct",
-  "meta/llama-4-maverick": "meta-llama/llama-4-maverick-17b-128e-instruct",
 } as const satisfies Partial<Record<CanonicalModelId, string>>;
 
 export const withCanonicalIdsForGroq = (


### PR DESCRIPTION
Remove deprecated Groq models from canonical mappings and provider lists.

- Remove Llama 4 Maverick from Groq canonical mapping (deprecated 03/09/26)
- Remove "groq" provider from Llama models no longer available on Groq (3.1-70b, 3.1-405b, 3.2-*)
- Keep "groq" only for models still active: Llama 3.1 8B, Llama 3.3 70B, Llama 4 Scout, GPT-OSS 20B/120B

Closes #148

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Groq provider compatibility: added support for Llama 3.1 8B, Llama 3.3 70B, and Llama 4 Scout models; removed support for Llama 4 Maverick and adjusted base configurations for other Llama variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->