### PR TITLE
feat: add xAI (Grok) provider with reasoning middleware and grok-4.2 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ console.log(text);
 
 Hebo Gateway’s provider registry accepts any **Vercel AI SDK Provider**. For Hebo to be able to route a model across different providers, the names need to be canonicalized to a common form, for example 'openai/gpt-4.1-mini' instead of 'gpt-4.1-mini'.
 
-We currently provide out-of-the-box canonical providers for: `Bedrock`, `Anthropic`, `Cohere`, `Vertex`, `Groq`, `OpenAI`, and `Voyage`. Import the helper from the matching package path:
+We currently provide out-of-the-box canonical providers for: `Bedrock`, `Anthropic`, `Cohere`, `Vertex`, `Groq`, `OpenAI`, `Voyage`, and `xAI`. Import the helper from the matching package path:
 
 ```ts
 // pattern: @hebo-ai/gateway/providers/<provider>
@@ -237,6 +237,9 @@ Out-of-the-box model presets:
 
 - **Voyage** — `@hebo-ai/gateway/models/voyage`  
   Voyage: `voyage` (`v2`, `v3`, `v3.5`, `v4`, `v2.x`, `v3.x`, `v4.x`, `latest`, `all`)
+
+- **xAI** — `@hebo-ai/gateway/models/xai`  
+  Grok: `grok` (`v4.1`, `v4.2`, `latest`, `all`)
 
 #### User-defined Models
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@ai-sdk/google-vertex": "^4.0.105",
         "@ai-sdk/groq": "^3.0.35",
         "@ai-sdk/openai": "^3.0.52",
+        "@ai-sdk/xai": "^3.0.83",
         "@anthropic-ai/sdk": "^0.88.0",
         "@aws-sdk/credential-providers": "^3.1027.0",
         "@langfuse/otel": "^5.0.2",
@@ -108,6 +109,8 @@
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.23", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg=="],
+
+    "@ai-sdk/xai": ["@ai-sdk/xai@3.0.83", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.41", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-SuQz68BZGeuZjrSUJAzku97IlhdiNJJBsvG/Tvm3K2tuxkBS7TJq0fH4/AzAM7w2H2jxVUgboP7kRR6IfpRxcg=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.88.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "tanstack-start",
     "vercel-ai-sdk",
     "vertex",
-    "voyage"
+    "voyage",
+    "xai"
   ],
   "homepage": "https://hebo.ai/gateway",
   "bugs": {
@@ -124,6 +125,10 @@
       "types": "./dist/models/voyage/index.d.ts",
       "import": "./dist/models/voyage/index.js"
     },
+    "./models/xai": {
+      "types": "./dist/models/xai/index.d.ts",
+      "import": "./dist/models/xai/index.js"
+    },
     "./providers/anthropic": {
       "types": "./dist/providers/anthropic/index.d.ts",
       "import": "./dist/providers/anthropic/index.js"
@@ -151,6 +156,10 @@
     "./providers/voyage": {
       "types": "./dist/providers/voyage/index.d.ts",
       "import": "./dist/providers/voyage/index.js"
+    },
+    "./providers/xai": {
+      "types": "./dist/providers/xai/index.d.ts",
+      "import": "./dist/providers/xai/index.js"
     },
     "./telemetry": {
       "types": "./dist/telemetry/index.d.ts",
@@ -186,6 +195,7 @@
     "@ai-sdk/google-vertex": "^4.0.105",
     "@ai-sdk/groq": "^3.0.35",
     "@ai-sdk/openai": "^3.0.52",
+    "@ai-sdk/xai": "^3.0.83",
     "@anthropic-ai/sdk": "^0.88.0",
     "@aws-sdk/credential-providers": "^3.1027.0",
     "@langfuse/otel": "^5.0.2",
@@ -228,6 +238,7 @@
     "@ai-sdk/google-vertex": "^4.0.80",
     "@ai-sdk/groq": "^3.0.29",
     "@ai-sdk/openai": "^3.0.41",
+    "@ai-sdk/xai": "^3.0.83",
     "@libsql/client": "^0.14.0",
     "@opentelemetry/api": "^1.9.1",
     "better-sqlite3": "^11.0.0",
@@ -257,6 +268,9 @@
       "optional": true
     },
     "@ai-sdk/openai": {
+      "optional": true
+    },
+    "@ai-sdk/xai": {
       "optional": true
     },
     "voyage-ai-provider": {

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -89,6 +89,12 @@ export const CANONICAL_MODEL_IDS = [
   "cohere/command-a-vision",
   "cohere/command-r",
   "cohere/command-r-plus",
+  // xAI
+  "xai/grok-4.1-fast",
+  "xai/grok-4.1-fast-reasoning",
+  "xai/grok-4.2",
+  "xai/grok-4.2-reasoning",
+  "xai/grok-4.2-multi-agent",
   // Voyage
   "voyage/voyage-2-code",
   "voyage/voyage-2-law",

--- a/src/models/xai/index.ts
+++ b/src/models/xai/index.ts
@@ -1,0 +1,2 @@
+export * from "./middleware";
+export * from "./presets";

--- a/src/models/xai/middleware.test.ts
+++ b/src/models/xai/middleware.test.ts
@@ -104,10 +104,86 @@ test("xaiReasoningMiddleware > should map medium effort to high", async () => {
   });
 });
 
+test("xaiReasoningMiddleware > should map minimal effort to low", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: { enabled: true, effort: "minimal" },
+      },
+    },
+  };
+
+  const result = await xaiReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3(),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      xai: { reasoningEffort: "low" },
+      unknown: {},
+    },
+  });
+});
+
+test("xaiReasoningMiddleware > should map xhigh effort to high", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: { enabled: true, effort: "xhigh" },
+      },
+    },
+  };
+
+  const result = await xaiReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3(),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      xai: { reasoningEffort: "high" },
+      unknown: {},
+    },
+  });
+});
+
+test("xaiReasoningMiddleware > should map max effort to high", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: { enabled: true, effort: "max" },
+      },
+    },
+  };
+
+  const result = await xaiReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3(),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      xai: { reasoningEffort: "high" },
+      unknown: {},
+    },
+  });
+});
+
 test("xaiReasoningMiddleware > should clear reasoning when disabled", async () => {
   const params = {
     prompt: [],
     providerOptions: {
+      xai: { reasoningEffort: "high" },
       unknown: {
         reasoning: { enabled: false },
       },

--- a/src/models/xai/middleware.test.ts
+++ b/src/models/xai/middleware.test.ts
@@ -1,0 +1,155 @@
+import { expect, test } from "bun:test";
+
+import { MockLanguageModelV3 } from "ai/test";
+
+import { modelMiddlewareMatcher } from "../../middleware/matcher";
+import { CANONICAL_MODEL_IDS } from "../../models/types";
+import { xaiReasoningMiddleware } from "./middleware";
+
+test("xai middleware > matching patterns", () => {
+  const languageMatching = [
+    "xai/grok-4.1-fast-reasoning",
+    "xai/grok-4.2-reasoning",
+    "xai/grok-4.2-multi-agent",
+  ] satisfies (typeof CANONICAL_MODEL_IDS)[number][];
+
+  const languageNonMatching = [
+    "xai/grok-4.1-fast",
+    "xai/grok-4.2",
+  ] satisfies (typeof CANONICAL_MODEL_IDS)[number][];
+
+  for (const id of languageMatching) {
+    const middleware = modelMiddlewareMatcher.resolve({ kind: "text", modelId: id });
+    expect(middleware).toContain(xaiReasoningMiddleware);
+  }
+
+  for (const id of languageNonMatching) {
+    const middleware = modelMiddlewareMatcher.resolve({ kind: "text", modelId: id });
+    expect(middleware).not.toContain(xaiReasoningMiddleware);
+  }
+});
+
+test("xaiReasoningMiddleware > should map low effort to low", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: { enabled: true, effort: "low" },
+      },
+    },
+  };
+
+  const result = await xaiReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3(),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      xai: { reasoningEffort: "low" },
+      unknown: {},
+    },
+  });
+});
+
+test("xaiReasoningMiddleware > should map high effort to high", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: { enabled: true, effort: "high" },
+      },
+    },
+  };
+
+  const result = await xaiReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3(),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      xai: { reasoningEffort: "high" },
+      unknown: {},
+    },
+  });
+});
+
+test("xaiReasoningMiddleware > should map medium effort to high", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: { enabled: true, effort: "medium" },
+      },
+    },
+  };
+
+  const result = await xaiReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3(),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      xai: { reasoningEffort: "high" },
+      unknown: {},
+    },
+  });
+});
+
+test("xaiReasoningMiddleware > should clear reasoning when disabled", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: { enabled: false },
+      },
+    },
+  };
+
+  const result = await xaiReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3(),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      xai: { reasoningEffort: undefined },
+      unknown: {},
+    },
+  });
+});
+
+test("xaiReasoningMiddleware > should map none effort to undefined", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: { enabled: true, effort: "none" },
+      },
+    },
+  };
+
+  const result = await xaiReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3(),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      xai: { reasoningEffort: undefined },
+      unknown: {},
+    },
+  });
+});

--- a/src/models/xai/middleware.ts
+++ b/src/models/xai/middleware.ts
@@ -1,0 +1,48 @@
+import type { XaiLanguageModelChatOptions } from "@ai-sdk/xai";
+import type { LanguageModelMiddleware } from "ai";
+
+import type { ChatCompletionsReasoningConfig } from "../../endpoints/chat-completions/schema";
+import { modelMiddlewareMatcher } from "../../middleware/matcher";
+
+export const xaiReasoningMiddleware: LanguageModelMiddleware = {
+  specificationVersion: "v3",
+  // oxlint-disable-next-line require-await
+  transformParams: async ({ params }) => {
+    const unknown = params.providerOptions?.["unknown"];
+    if (!unknown) return params;
+
+    const reasoning = unknown["reasoning"] as ChatCompletionsReasoningConfig;
+    if (!reasoning) return params;
+
+    const target = (params.providerOptions!["xai"] ??= {}) as XaiLanguageModelChatOptions;
+
+    if (reasoning.enabled === false) {
+      target.reasoningEffort = undefined;
+    } else if (reasoning.effort) {
+      switch (reasoning.effort) {
+        case "none":
+          target.reasoningEffort = undefined;
+          break;
+        case "minimal":
+        case "low":
+          target.reasoningEffort = "low";
+          break;
+        case "medium":
+        case "high":
+        case "xhigh":
+        case "max":
+          target.reasoningEffort = "high";
+          break;
+      }
+    }
+
+    delete unknown["reasoning"];
+
+    return params;
+  },
+};
+
+modelMiddlewareMatcher.useForModel(
+  ["xai/grok-4.1-fast-reasoning", "xai/grok-4.2-reasoning", "xai/grok-4.2-multi-agent"],
+  { language: [xaiReasoningMiddleware] },
+);

--- a/src/models/xai/presets.ts
+++ b/src/models/xai/presets.ts
@@ -1,0 +1,79 @@
+import type { CanonicalProviderId } from "../../providers/types";
+import { presetFor, type DeepPartial } from "../../utils/preset";
+import type { CanonicalModelId, CatalogModel } from "../types";
+
+const GROK_BASE = {
+  modalities: {
+    input: ["text", "image"] as const,
+    output: ["text"] as const,
+  },
+  capabilities: ["tool_call", "structured_output", "temperature"] as const,
+  providers: ["xai"] as const satisfies readonly CanonicalProviderId[],
+  context: 2000000,
+} satisfies DeepPartial<CatalogModel>;
+
+const GROK_REASONING_BASE = {
+  ...GROK_BASE,
+  capabilities: ["tool_call", "structured_output", "reasoning", "temperature"] as const,
+} satisfies DeepPartial<CatalogModel>;
+
+export const grok41Fast = presetFor<CanonicalModelId, CatalogModel>()(
+  "xai/grok-4.1-fast" as const,
+  {
+    ...GROK_BASE,
+    name: "Grok 4.1 Fast",
+    created: "2025-11-20",
+    knowledge: "2025-06",
+  } satisfies CatalogModel,
+);
+
+export const grok41FastReasoning = presetFor<CanonicalModelId, CatalogModel>()(
+  "xai/grok-4.1-fast-reasoning" as const,
+  {
+    ...GROK_REASONING_BASE,
+    name: "Grok 4.1 Fast Reasoning",
+    created: "2025-11-20",
+    knowledge: "2025-06",
+  } satisfies CatalogModel,
+);
+
+export const grok42 = presetFor<CanonicalModelId, CatalogModel>()("xai/grok-4.2" as const, {
+  ...GROK_BASE,
+  name: "Grok 4.2",
+  created: "2026-03-16",
+  knowledge: "2024-11",
+} satisfies CatalogModel);
+
+export const grok42Reasoning = presetFor<CanonicalModelId, CatalogModel>()(
+  "xai/grok-4.2-reasoning" as const,
+  {
+    ...GROK_REASONING_BASE,
+    name: "Grok 4.2 Reasoning",
+    created: "2026-03-16",
+    knowledge: "2024-11",
+  } satisfies CatalogModel,
+);
+
+export const grok42MultiAgent = presetFor<CanonicalModelId, CatalogModel>()(
+  "xai/grok-4.2-multi-agent" as const,
+  {
+    ...GROK_REASONING_BASE,
+    name: "Grok 4.2 Multi-Agent",
+    created: "2026-03-16",
+    knowledge: "2024-11",
+  } satisfies CatalogModel,
+);
+
+const grokAtomic = {
+  "v4.1": [grok41Fast, grok41FastReasoning],
+  "v4.2": [grok42, grok42Reasoning, grok42MultiAgent],
+} as const;
+
+const grokGroups = {} as const;
+
+export const grok = {
+  ...grokAtomic,
+  ...grokGroups,
+  latest: [grok42, grok42Reasoning],
+  all: Object.values(grokAtomic).flat(),
+} as const;

--- a/src/models/xai/presets.ts
+++ b/src/models/xai/presets.ts
@@ -74,6 +74,6 @@ const grokGroups = {} as const;
 export const grok = {
   ...grokAtomic,
   ...grokGroups,
-  latest: [grok42, grok42Reasoning],
+  latest: [grok42, grok42Reasoning, grok42MultiAgent],
   all: Object.values(grokAtomic).flat(),
 } as const;

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -9,6 +9,7 @@ export const CANONICAL_PROVIDER_IDS = [
   "openai",
   "vertex",
   "voyage",
+  "xai",
 ] as const;
 
 export type CanonicalProviderId = (typeof CANONICAL_PROVIDER_IDS)[number];

--- a/src/providers/xai/canonical.test.ts
+++ b/src/providers/xai/canonical.test.ts
@@ -4,14 +4,21 @@ import { xai } from "@ai-sdk/xai";
 
 import { withCanonicalIdsForXai } from "./canonical";
 
-test("withCanonicalIdsForXai > maps canonical IDs to xAI native model IDs", () => {
+test("withCanonicalIdsForXai > maps grok-4.1-fast via explicit mapping", () => {
   const provider = withCanonicalIdsForXai(xai);
 
   const model = provider.languageModel("xai/grok-4.1-fast");
   expect(model.modelId).toBe("grok-4-1-fast-non-reasoning");
 });
 
-test("withCanonicalIdsForXai > maps reasoning model IDs", () => {
+test("withCanonicalIdsForXai > normalizes grok-4.1-fast-reasoning via delimiter fallback", () => {
+  const provider = withCanonicalIdsForXai(xai);
+
+  const model = provider.languageModel("xai/grok-4.1-fast-reasoning");
+  expect(model.modelId).toBe("grok-4-1-fast-reasoning");
+});
+
+test("withCanonicalIdsForXai > maps grok-4.2 reasoning via explicit mapping", () => {
   const provider = withCanonicalIdsForXai(xai);
 
   const model = provider.languageModel("xai/grok-4.2-reasoning");

--- a/src/providers/xai/canonical.test.ts
+++ b/src/providers/xai/canonical.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+
+import { xai } from "@ai-sdk/xai";
+
+import { withCanonicalIdsForXai } from "./canonical";
+
+test("withCanonicalIdsForXai > maps canonical IDs to xAI native model IDs", () => {
+  const provider = withCanonicalIdsForXai(xai);
+
+  const model = provider.languageModel("xai/grok-4.1-fast");
+  expect(model.modelId).toBe("grok-4-1-fast-non-reasoning");
+});
+
+test("withCanonicalIdsForXai > maps reasoning model IDs", () => {
+  const provider = withCanonicalIdsForXai(xai);
+
+  const model = provider.languageModel("xai/grok-4.2-reasoning");
+  expect(model.modelId).toBe("grok-4.20-0309-reasoning");
+});
+
+test("withCanonicalIdsForXai > supports extra mapping override", () => {
+  const provider = withCanonicalIdsForXai(xai, {
+    "xai/custom-model": "custom-native-id",
+  });
+
+  const model = provider.languageModel("xai/custom-model");
+  expect(model.modelId).toBe("custom-native-id");
+});

--- a/src/providers/xai/canonical.test.ts
+++ b/src/providers/xai/canonical.test.ts
@@ -18,11 +18,25 @@ test("withCanonicalIdsForXai > normalizes grok-4.1-fast-reasoning via delimiter 
   expect(model.modelId).toBe("grok-4-1-fast-reasoning");
 });
 
+test("withCanonicalIdsForXai > maps grok-4.2 via explicit mapping", () => {
+  const provider = withCanonicalIdsForXai(xai);
+
+  const model = provider.languageModel("xai/grok-4.2");
+  expect(model.modelId).toBe("grok-4.20-0309-non-reasoning");
+});
+
 test("withCanonicalIdsForXai > maps grok-4.2 reasoning via explicit mapping", () => {
   const provider = withCanonicalIdsForXai(xai);
 
   const model = provider.languageModel("xai/grok-4.2-reasoning");
   expect(model.modelId).toBe("grok-4.20-0309-reasoning");
+});
+
+test("withCanonicalIdsForXai > maps grok-4.2-multi-agent via explicit mapping", () => {
+  const provider = withCanonicalIdsForXai(xai);
+
+  const model = provider.languageModel("xai/grok-4.2-multi-agent");
+  expect(model.modelId).toBe("grok-4.20-multi-agent-0309");
 });
 
 test("withCanonicalIdsForXai > supports extra mapping override", () => {

--- a/src/providers/xai/canonical.ts
+++ b/src/providers/xai/canonical.ts
@@ -5,7 +5,6 @@ import { withCanonicalIds } from "../registry";
 
 const MAPPING = {
   "xai/grok-4.1-fast": "grok-4-1-fast-non-reasoning",
-  "xai/grok-4.1-fast-reasoning": "grok-4-1-fast-reasoning",
   "xai/grok-4.2": "grok-4.20-0309-non-reasoning",
   "xai/grok-4.2-reasoning": "grok-4.20-0309-reasoning",
   "xai/grok-4.2-multi-agent": "grok-4.20-multi-agent-0309",
@@ -13,9 +12,9 @@ const MAPPING = {
 
 export const withCanonicalIdsForXai = (
   provider: XaiProvider,
-  extraMapping?: Record<ModelId, string>,
+  extraMapping?: Partial<Record<ModelId, string>>,
 ) =>
   withCanonicalIds(provider, {
     mapping: { ...MAPPING, ...extraMapping },
-    options: { stripNamespace: true },
+    options: { stripNamespace: true, normalizeDelimiters: true },
   });

--- a/src/providers/xai/canonical.ts
+++ b/src/providers/xai/canonical.ts
@@ -1,0 +1,21 @@
+import { type XaiProvider } from "@ai-sdk/xai";
+
+import type { CanonicalModelId, ModelId } from "../../models/types";
+import { withCanonicalIds } from "../registry";
+
+const MAPPING = {
+  "xai/grok-4.1-fast": "grok-4-1-fast-non-reasoning",
+  "xai/grok-4.1-fast-reasoning": "grok-4-1-fast-reasoning",
+  "xai/grok-4.2": "grok-4.20-0309-non-reasoning",
+  "xai/grok-4.2-reasoning": "grok-4.20-0309-reasoning",
+  "xai/grok-4.2-multi-agent": "grok-4.20-multi-agent-0309",
+} as const satisfies Partial<Record<CanonicalModelId, string>>;
+
+export const withCanonicalIdsForXai = (
+  provider: XaiProvider,
+  extraMapping?: Record<ModelId, string>,
+) =>
+  withCanonicalIds(provider, {
+    mapping: { ...MAPPING, ...extraMapping },
+    options: { stripNamespace: true },
+  });

--- a/src/providers/xai/index.ts
+++ b/src/providers/xai/index.ts
@@ -1,0 +1,1 @@
+export * from "./canonical";


### PR DESCRIPTION
Add xAI as a new provider using `@ai-sdk/xai` with canonical ID mapping, reasoning middleware, and model presets for grok-4.1-fast, grok-4.1-fast-reasoning, grok-4.2, grok-4.2-reasoning, and grok-4.2-multi-agent.

Closes #136

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * XAI provider integration with Grok models and five new Grok variants
  * Configurable reasoning for Grok models with mapped effort levels

* **Tests**
  * Added test coverage for XAI model canonicalization and reasoning middleware behavior

* **Chores**
  * Package metadata and public entrypoints updated to expose XAI models/providers

* **Documentation**
  * README updated to document XAI provider and Grok presets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->