### PR TITLE
fix(messages): preserve content block order in user messages

### DIFF
--- a/src/endpoints/messages/converters.test.ts
+++ b/src/endpoints/messages/converters.test.ts
@@ -471,6 +471,38 @@ describe("Messages Converters", () => {
       expect(messages[0]!.role).toBe("user");
       expect(messages[1]!.role).toBe("tool");
     });
+
+    test("should preserve part order when tool_result precedes text", () => {
+      const messages = convertToModelMessages([
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me read those files." },
+            { type: "tool_use", id: "call_A", name: "Read", input: {} },
+            { type: "tool_use", id: "call_B", name: "Read", input: {} },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "call_A", content: "file a" },
+            { type: "tool_result", tool_use_id: "call_B", content: "file b" },
+            { type: "text", text: "additional text" },
+          ],
+        },
+      ]);
+
+      // assistant + tool + user (tool results before text, matching input order)
+      expect(messages).toHaveLength(3);
+      expect(messages[0]!.role).toBe("assistant");
+      expect(messages[1]!.role).toBe("tool");
+      expect(messages[2]!.role).toBe("user");
+
+      const toolContent = (messages[1] as { content: { toolCallId: string }[] }).content;
+      expect(toolContent).toHaveLength(2);
+      expect(toolContent[0]!.toolCallId).toBe("call_A");
+      expect(toolContent[1]!.toolCallId).toBe("call_B");
+    });
   });
 
   describe("convertToToolSet", () => {

--- a/src/endpoints/messages/converters.test.ts
+++ b/src/endpoints/messages/converters.test.ts
@@ -502,6 +502,10 @@ describe("Messages Converters", () => {
       expect(toolContent).toHaveLength(2);
       expect(toolContent[0]!.toolCallId).toBe("call_A");
       expect(toolContent[1]!.toolCallId).toBe("call_B");
+
+      const userContent = (messages[2] as { content: { type: string; text: string }[] }).content;
+      expect(userContent).toHaveLength(1);
+      expect(userContent[0]!.text).toBe("additional text");
     });
   });
 

--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -4,7 +4,6 @@ import type {
   FinishReason,
   ToolSet,
   ModelMessage,
-  UserContent,
   AssistantContent,
   LanguageModelUsage,
   TextStreamPart,
@@ -215,39 +214,32 @@ function fromUserMessage(
   message: MessagesMessage & { role: "user" },
   toolNameMap: Map<string, string>,
 ): Array<UserModelMessage | ToolModelMessage> {
-  const result: Array<UserModelMessage | ToolModelMessage> = [];
-
   if (typeof message.content === "string") {
-    result.push({ role: "user", content: message.content });
-    return result;
+    return [{ role: "user", content: message.content }];
   }
 
-  const userParts: UserContent = [];
-  const toolResultParts: ToolResultPart[] = [];
+  const result: Array<UserModelMessage | ToolModelMessage> = [];
+  let currentParts: Array<TextPart | ImagePart | FilePart | ToolResultPart> = [];
+  let currentRole: string | undefined;
 
   for (const block of message.content) {
-    if (block.type === "tool_result") {
-      toolResultParts.push(fromToolResultBlock(block, toolNameMap));
+    const isToolResult = block.type === "tool_result";
+    const role = isToolResult ? "tool" : "user";
+    const part = isToolResult
+      ? fromToolResultBlock(block, toolNameMap)
+      : fromUserContentBlock(block);
+    if (!part) continue;
+
+    if (role === currentRole) {
+      currentParts.push(part);
     } else {
-      const part = fromUserContentBlock(block);
-      if (part) userParts.push(part);
+      currentParts = [part];
+      currentRole = role;
+      result.push({ role, content: currentParts } as UserModelMessage | ToolModelMessage);
     }
   }
 
-  if (userParts.length > 0) {
-    result.push({ role: "user", content: userParts });
-  }
-
-  if (toolResultParts.length > 0) {
-    result.push({ role: "tool", content: toolResultParts });
-  }
-
-  // If only tool results and no user parts, still valid
-  if (userParts.length === 0 && toolResultParts.length === 0) {
-    result.push({ role: "user", content: "" });
-  }
-
-  return result;
+  return result.length > 0 ? result : [{ role: "user" as const, content: "" }];
 }
 
 function fromUserContentBlock(


### PR DESCRIPTION
## Summary

- Fixes `fromUserMessage` to preserve the original order of content blocks instead of always emitting user parts before tool results
- Consecutive same-role parts are coalesced into a single message

Fixes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test verifying conversion of mixed assistant, tool-use, tool-result, and user text blocks into three ordered model messages.

* **Refactor**
  * Streamlined message conversion to incrementally group consecutive content by role and simplified fallback for empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->