### PR TITLE
fix: accept array content in system messages for chat-completions

### DIFF
--- a/src/endpoints/chat-completions/converters.test.ts
+++ b/src/endpoints/chat-completions/converters.test.ts
@@ -685,6 +685,66 @@ describe("Chat Completions Converters", () => {
       });
     });
 
+    test("should normalize array content in system message to string", () => {
+      const result = convertToTextCallOptions({
+        messages: [
+          {
+            role: "system",
+            content: [
+              { type: "text", text: "You are a helpful assistant." },
+            ],
+          },
+          { role: "user", content: "hi" },
+        ],
+      });
+
+      expect(result.messages[0]).toMatchObject({
+        role: "system",
+        content: "You are a helpful assistant.",
+      });
+    });
+
+    test("should concatenate multiple array content parts in system message", () => {
+      const result = convertToTextCallOptions({
+        messages: [
+          {
+            role: "system",
+            content: [
+              { type: "text", text: "You are Brave Assistant, " },
+              { type: "text", text: "a helpful AI." },
+            ],
+          },
+          { role: "user", content: "hi" },
+        ],
+      });
+
+      expect(result.messages[0]).toMatchObject({
+        role: "system",
+        content: "You are Brave Assistant, a helpful AI.",
+      });
+    });
+
+    test("should preserve cache_control on system message with array content", () => {
+      const result = convertToTextCallOptions({
+        messages: [
+          {
+            role: "system",
+            content: [{ type: "text", text: "Policy block" }],
+            cache_control: { type: "ephemeral", ttl: "1h" },
+          },
+        ],
+      });
+
+      expect(result.messages[0]).toMatchObject({
+        role: "system",
+        content: "Policy block",
+      });
+      expect(result.messages[0]!.providerOptions!["unknown"]!["cache_control"]).toEqual({
+        type: "ephemeral",
+        ttl: "1h",
+      });
+    });
+
     test("should map service_tier into providerOptions.unknown", () => {
       const result = convertToTextCallOptions({
         messages: [{ role: "user", content: "hi" }],

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -143,12 +143,16 @@ export function convertToModelMessages(messages: ChatCompletionsMessage[]): Mode
     if (message.role === "tool") continue;
 
     if (message.role === "system") {
+      const content = Array.isArray(message.content)
+        ? message.content.map((p) => p.text).join("")
+        : message.content;
+      const out: ModelMessage = { role: "system", content };
       if (message.cache_control) {
-        (message as ModelMessage).providerOptions = {
+        out.providerOptions = {
           unknown: { cache_control: message.cache_control },
         };
       }
-      modelMessages.push(message);
+      modelMessages.push(out);
       continue;
     }
 

--- a/src/endpoints/chat-completions/schema.ts
+++ b/src/endpoints/chat-completions/schema.ts
@@ -83,7 +83,7 @@ export type ChatCompletionsToolCall = z.infer<typeof ChatCompletionsToolCallSche
 
 export const ChatCompletionsSystemMessageSchema = z.object({
   role: z.literal("system"),
-  content: z.string(),
+  content: z.union([z.string(), z.array(ChatCompletionsContentPartTextSchema)]),
   name: z.string().optional(),
   // Extension origin: OpenRouter/Vercel/Anthropic
   cache_control: ChatCompletionsCacheControlSchema.optional().meta({ extension: true }),


### PR DESCRIPTION
## Summary

- Fix Brave Leo AI "expected string, received array" error on `/v1/chat/completions`
- Update system message schema to accept both string and array content (matching OpenAI spec)
- Normalize array content to string in the converter for downstream providers

Closes #168

Generated with [Claude Code](https://claude.ai/claude-code)