### PR TITLE
fix(messages): preserve provider metadata on streamed tool_use blocks

### DIFF
--- a/src/endpoints/messages/converters.test.ts
+++ b/src/endpoints/messages/converters.test.ts
@@ -1223,6 +1223,61 @@ describe("Messages Converters", () => {
       }
     });
 
+    test("should surface provider metadata from tool-input-start on the tool_use block", async () => {
+      // Gemini streams tool calls via tool-input-start, and carries its
+      // `thoughtSignature` on the providerMetadata of that part. We must
+      // forward it to the `content_block_start` as `extra_content` so that
+      // the next turn can echo it back to Vertex.
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "tool-input-start",
+            id: "call_gemini",
+            toolName: "WebSearch",
+            providerMetadata: { google: { thoughtSignature: "sig_abc" } },
+          });
+          controller.enqueue({
+            type: "tool-input-delta",
+            id: "call_gemini",
+            delta: '{"q":"hi"}',
+          });
+          controller.enqueue({
+            type: "tool-call",
+            toolCallId: "call_gemini",
+            toolName: "WebSearch",
+            input: { q: "hi" },
+            providerMetadata: { google: { thoughtSignature: "sig_abc" } },
+          });
+          controller.enqueue({
+            type: "finish",
+            finishReason: "tool-calls",
+            rawFinishReason: "tool_calls",
+            totalUsage: mockUsage({ outputTokens: 5 }),
+          });
+          controller.close();
+        },
+      });
+
+      const transformed = stream.pipeThrough(new MessagesTransformStream("test-model"));
+      const { events } = await collectStreamEvents(transformed);
+
+      const toolStart = events.find(
+        (e) =>
+          e.event === "content_block_start" &&
+          "content_block" in e.data &&
+          e.data.content_block.type === "tool_use",
+      );
+      expect(toolStart).toBeDefined();
+      if (
+        toolStart?.event === "content_block_start" &&
+        toolStart.data.content_block.type === "tool_use"
+      ) {
+        expect(toolStart.data.content_block.extra_content).toEqual({
+          google: { thoughtSignature: "sig_abc" },
+        });
+      }
+    });
+
     test("should stream non-streaming tool call events", async () => {
       const stream = new ReadableStream<TextStreamPart<ToolSet>>({
         start(controller) {

--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -674,17 +674,26 @@ export class MessagesTransformStream extends TransformStream<
           case "tool-input-start": {
             currentToolCallId = part.id;
 
+            const contentBlock: Extract<
+              ContentBlockStartEvent["data"]["content_block"],
+              { type: "tool_use" }
+            > = {
+              type: "tool_use",
+              id: part.id,
+              name: normalizeToolName(part.toolName),
+              input: {} as Record<string, never>,
+            };
+            // Preserve provider metadata (e.g. Gemini `thoughtSignature`) so the
+            // client can echo it back on the next turn. Without this, Vertex
+            // rejects the follow-up request with a missing `thought_signature`.
+            if (part.providerMetadata) contentBlock.extra_content = part.providerMetadata;
+
             controller.enqueue({
               event: "content_block_start",
               data: {
                 type: "content_block_start",
                 index: blockIndex,
-                content_block: {
-                  type: "tool_use",
-                  id: part.id,
-                  name: normalizeToolName(part.toolName),
-                  input: {} as Record<string, never>,
-                },
+                content_block: contentBlock,
               },
             });
             break;

--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -683,9 +683,6 @@ export class MessagesTransformStream extends TransformStream<
               name: normalizeToolName(part.toolName),
               input: {} as Record<string, never>,
             };
-            // Preserve provider metadata (e.g. Gemini `thoughtSignature`) so the
-            // client can echo it back on the next turn. Without this, Vertex
-            // rejects the follow-up request with a missing `thought_signature`.
             if (part.providerMetadata) contentBlock.extra_content = part.providerMetadata;
 
             controller.enqueue({


### PR DESCRIPTION
## Summary

- Forward `providerMetadata` from `tool-input-start` onto the streaming `content_block_start` payload as `extra_content`, matching the non-streaming `tool-call` branch.
- This stops the streaming serializer from silently dropping Gemini's `thoughtSignature`, unblocking the SDK-to-SDK and `/conversations` round-trip.
- Added a regression test in `converters.test.ts` that asserts the Gemini-shaped signature lands on `extra_content`.

## Test plan
- [x] `bun run lint`
- [x] `bun test src/endpoints/messages/converters.test.ts`
- [ ] Manual check against a Vertex/Gemini model via Claude Code (still requires follow-up fix #2 for Claude Code specifically)

Refs #171

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming message processing so provider-specific metadata is preserved and included in tool operation blocks; metadata now flows correctly through the message conversion pipeline.

* **Tests**
  * Added test coverage to verify provider metadata is accurately retained and emitted during tool input streaming operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->