### PR TITLE
feat(models): add OpenAI GPT-5.5 and GPT-5.5 Pro

### DIFF
--- a/src/models/openai/middleware.test.ts
+++ b/src/models/openai/middleware.test.ts
@@ -19,6 +19,8 @@ test("openAI middleware > matching patterns", () => {
     "openai/gpt-5.4-mini",
     "openai/gpt-5.4-nano",
     "openai/gpt-5.4-pro",
+    "openai/gpt-5.5",
+    "openai/gpt-5.5-pro",
     "openai/gpt-oss-20b",
   ] satisfies (typeof CANONICAL_MODEL_IDS)[number][];
 

--- a/src/models/openai/presets.ts
+++ b/src/models/openai/presets.ts
@@ -371,7 +371,8 @@ export const gptOss = {
 export const gpt = {
   ...gptAtomic,
   ...gptGroups,
-  latest: [gpt55, gpt55Pro],
+  // 5.5 Mini/Nano not released yet; keep 5.4 small variants in `latest` until they ship.
+  latest: [gpt55, gpt55Pro, gpt54Mini, gpt54Nano],
   all: Object.values(gptAtomic).flat(),
 } as const;
 

--- a/src/models/openai/presets.ts
+++ b/src/models/openai/presets.ts
@@ -258,6 +258,22 @@ export const gpt54Pro = presetFor<CanonicalModelId, CatalogModel>()("openai/gpt-
   context: 1050000,
 } satisfies CatalogModel);
 
+export const gpt55 = presetFor<CanonicalModelId, CatalogModel>()("openai/gpt-5.5" as const, {
+  ...GPT_BASE,
+  name: "GPT-5.5",
+  created: "2026-04-22",
+  knowledge: "2025-08",
+  context: 1050000,
+} satisfies CatalogModel);
+
+export const gpt55Pro = presetFor<CanonicalModelId, CatalogModel>()("openai/gpt-5.5-pro" as const, {
+  ...GPT_PRO_BASE,
+  name: "GPT-5.5 Pro",
+  created: "2026-04-24",
+  knowledge: "2025-12",
+  context: 1050000,
+} satisfies CatalogModel);
+
 export const textEmbedding3Small = presetFor<CanonicalModelId, CatalogModel>()(
   "openai/text-embedding-3-small" as const,
   {
@@ -312,6 +328,7 @@ const gptAtomic = {
   "v5.2": [gpt52, gpt52Chat, gpt52Pro, gpt52Codex],
   "v5.3": [gpt53Codex, gpt53CodexSpark, gpt53Chat],
   "v5.4": [gpt54, gpt54Mini, gpt54Nano, gpt54Pro],
+  "v5.5": [gpt55, gpt55Pro],
   codex: [
     gpt5Codex,
     gpt51Codex,
@@ -322,7 +339,7 @@ const gptAtomic = {
     gpt53CodexSpark,
   ],
   chat: [gpt51Chat, gpt52Chat, gpt53Chat],
-  pro: [gpt5Pro, gpt52Pro, gpt54Pro],
+  pro: [gpt5Pro, gpt52Pro, gpt54Pro, gpt55Pro],
 } as const;
 
 const gptGroups = {
@@ -332,6 +349,7 @@ const gptGroups = {
     ...gptAtomic["v5.2"],
     ...gptAtomic["v5.3"],
     ...gptAtomic["v5.4"],
+    ...gptAtomic["v5.5"],
   ],
 } as const;
 
@@ -353,7 +371,7 @@ export const gptOss = {
 export const gpt = {
   ...gptAtomic,
   ...gptGroups,
-  latest: [gpt54, gpt54Mini, gpt54Nano],
+  latest: [gpt55, gpt55Pro],
   all: Object.values(gptAtomic).flat(),
 } as const;
 

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -31,6 +31,8 @@ export const CANONICAL_MODEL_IDS = [
   "openai/gpt-5.4-mini",
   "openai/gpt-5.4-nano",
   "openai/gpt-5.4-pro",
+  "openai/gpt-5.5",
+  "openai/gpt-5.5-pro",
   "openai/gpt-5-mini",
   "openai/gpt-5-nano",
   "openai/gpt-5-codex",


### PR DESCRIPTION
Adds canonical IDs and presets for `openai/gpt-5.5` and `openai/gpt-5.5-pro`.

## Changes
- Added canonical IDs to `src/models/types.ts`
- Added `gpt55` and `gpt55Pro` presets in `src/models/openai/presets.ts`
- Added `v5.5` atomic group; included in `v5.x` range, `pro` group, and `latest`

Metadata sourced from models.dev and OpenRouter:
- GPT-5.5: released 2026-04-22, knowledge cutoff 2025-08, context 1,050,000
- GPT-5.5 Pro: released 2026-04-24, knowledge cutoff 2025-12, context 1,050,000

Both resolve to the correct native IDs via the default `stripNamespace` transform — no explicit provider mapping needed.

Resolves #174

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GPT-5.5 and GPT-5.5 Pro models and added them to the model catalog.
  * Updated default model lineup to prioritize GPT-5.5 (while retaining 5.4 mini/nano variants).

* **Tests**
  * Expanded middleware tests to include the new GPT-5.5 model identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->