### PR TITLE
fix: record abort reason as span status message on client disconnect

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -73,12 +73,13 @@ export const winterCgHandler = (
       else if (status === 200 && ctx.response?.status) realStatus = ctx.response.status;
 
       if (realStatus !== 200) {
+        const err: unknown = reason ?? ctx.request.signal.reason;
         logger[realStatus >= 500 ? "error" : "warn"]({
           requestId: ctx.requestId,
-          err: reason ?? ctx.request.signal.reason,
+          err,
         });
 
-        span.recordError(reason, true);
+        span.recordError(err, true);
       }
       span.setAttributes({ "http.response.status_code_effective": realStatus });
 


### PR DESCRIPTION
## Summary
- Fix `span_status_message` being recorded as the literal string "undefined" when a streaming client disconnects mid-response.
- Apply the same `reason ?? ctx.request.signal.reason` fallback to `span.recordError` that the logger already uses, so the span matches the log.

Fixes #175

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling consistency in internal request lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->