### PR TITLE
fix: map AI SDK AbortError/TimeoutError to 504

### DIFF
--- a/src/errors/ai-sdk.ts
+++ b/src/errors/ai-sdk.ts
@@ -45,9 +45,21 @@ const normalizeApiCallError = (error: APICallError): GatewayError => {
   return new GatewayError(error, status, statusText, undefined, error.responseHeaders ?? undefined);
 };
 
+// `AbortError` / `TimeoutError` (raised by the AI SDK's internal `timeout` controller,
+// `AbortSignal.timeout`, or an aborted upstream `fetch`) reach us as plain DOMExceptions
+// that none of the AI SDK error classes match. Treat them as upstream gateway timeouts
+// so they surface as 504 with retry headers rather than defaulting to 500/502.
+// Inbound client disconnects are caught earlier in `lifecycle.ts` and overridden to 499.
+const isUpstreamAbortError = (error: unknown): boolean =>
+  error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+
 export const normalizeAiSdkError = (error: unknown): GatewayError | undefined => {
   if (APICallError.isInstance(error)) {
     return normalizeApiCallError(error);
+  }
+
+  if (isUpstreamAbortError(error)) {
+    return new GatewayError(error, 504, `UPSTREAM_${STATUS_TEXT(504)}`);
   }
 
   if (RetryError.isInstance(error)) {

--- a/src/errors/errors.test.ts
+++ b/src/errors/errors.test.ts
@@ -88,6 +88,24 @@ describe("normalizeAiSdkError", () => {
     const normalized = normalizeAiSdkError(apiError);
     expect(normalized!.headers).toBeUndefined();
   });
+
+  test("maps AbortError (upstream timeout) to 504 gateway timeout", () => {
+    const abortError = new DOMException("The operation was aborted.", "AbortError");
+
+    const normalized = normalizeAiSdkError(abortError);
+    expect(normalized).toBeInstanceOf(GatewayError);
+    expect(normalized!.status).toBe(504);
+    expect(normalized!.statusText).toBe("UPSTREAM_GATEWAY_TIMEOUT");
+  });
+
+  test("maps TimeoutError (AbortSignal.timeout) to 504 gateway timeout", () => {
+    const timeoutError = new DOMException("Signal timed out.", "TimeoutError");
+
+    const normalized = normalizeAiSdkError(timeoutError);
+    expect(normalized).toBeInstanceOf(GatewayError);
+    expect(normalized!.status).toBe(504);
+    expect(normalized!.statusText).toBe("UPSTREAM_GATEWAY_TIMEOUT");
+  });
 });
 
 describe("getErrorMeta", () => {

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -6,6 +6,7 @@ import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 import { MockProviderV3 } from "ai/test";
 
 import { models } from "./endpoints/models/handler";
+import { winterCgHandler } from "./lifecycle";
 
 describe("winterCgHandler", () => {
   afterEach(() => {
@@ -55,6 +56,35 @@ describe("winterCgHandler", () => {
     expect(onRequestTraceId).toBeDefined();
     expect(onResponseTraceId).toBeDefined();
     expect(onResponseTraceId).toBe(onRequestTraceId);
+  });
+
+  test("returns 499 when the client aborts the request, even if the handler throws an AbortError", async () => {
+    const controller = new AbortController();
+    // eslint-disable-next-line require-await
+    const handler = winterCgHandler(async (ctx) => {
+      ctx.operation = "chat";
+      controller.abort();
+      // Simulate the AI SDK propagating the aborted signal as a DOMException AbortError.
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }, {
+      providers: { openai: new MockProviderV3() },
+      models: {
+        "openai/gpt-oss-20b": {
+          name: "GPT-OSS 20B",
+          modalities: { input: ["text"], output: ["text"] },
+          providers: ["openai"],
+        },
+      },
+    });
+
+    const response = await handler(
+      new Request("http://localhost/v1/chat/completions", {
+        method: "POST",
+        signal: controller.signal,
+      }),
+    );
+
+    expect(response.status).toBe(499);
   });
 
   test("runs onError with the active span context without running onResponse", async () => {


### PR DESCRIPTION
Upstream aborts from the AI SDK's internal timeout or `AbortSignal.timeout` now surface as `504 UPSTREAM_GATEWAY_TIMEOUT` with `retry-after` + `x-should-retry: true`, instead of a generic 500 (non-streaming) or 502 (streaming).

Inbound client disconnects continue to produce 499 with no retry hint, unchanged.

Closes #181

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timeouts/cancelled upstream requests are now reported as upstream gateway timeouts (504) instead of generic errors.
  * Client-initiated aborts now result in a 499-style response when a handler observes an abort.

* **Tests**
  * Added tests covering timeout/cancellation mapping to 504.
  * Added a test validating client-abort behavior returns 499.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->