### PR TITLE
emit cache_creation.input_tokens on chat completions OTEL span

### DIFF
--- a/src/endpoints/chat-completions/otel.test.ts
+++ b/src/endpoints/chat-completions/otel.test.ts
@@ -323,6 +323,7 @@ describe("Chat Completions OTEL", () => {
         total_tokens: 30,
         prompt_tokens_details: {
           cached_tokens: 4,
+          cache_write_tokens: 5,
         },
         completion_tokens_details: {
           reasoning_tokens: 6,
@@ -336,6 +337,7 @@ describe("Chat Completions OTEL", () => {
     expect(attrs["gen_ai.usage.output_tokens"]).toBe(20);
     expect(attrs["gen_ai.usage.total_tokens"]).toBe(30);
     expect(attrs["gen_ai.usage.cache_read.input_tokens"]).toBe(4);
+    expect(attrs["gen_ai.usage.cache_creation.input_tokens"]).toBe(5);
     expect(attrs["gen_ai.usage.reasoning.output_tokens"]).toBe(6);
   });
 });

--- a/src/endpoints/chat-completions/otel.ts
+++ b/src/endpoints/chat-completions/otel.ts
@@ -197,6 +197,8 @@ export const getChatResponseAttributes = (
       "gen_ai.usage.input_tokens": completions.usage?.prompt_tokens,
       "gen_ai.usage.cache_read.input_tokens":
         completions.usage?.prompt_tokens_details?.cached_tokens,
+      "gen_ai.usage.cache_creation.input_tokens":
+        completions.usage?.prompt_tokens_details?.cache_write_tokens,
       "gen_ai.usage.output_tokens": completions.usage?.completion_tokens,
       "gen_ai.usage.reasoning.output_tokens":
         completions.usage?.completion_tokens_details?.reasoning_tokens,


### PR DESCRIPTION
## Summary

- Add missing `gen_ai.usage.cache_creation.input_tokens` OTEL attribute to the `/v1/chat/completions` response span, matching what `/v1/messages` already emits.

Closes open-telemetry/semantic-conventions#183

## Test plan

- [x] Existing tests pass
- [x] Updated usage test to assert `cache_creation.input_tokens` is set from `prompt_tokens_details.cache_write_tokens`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OpenTelemetry metrics for chat completions to include cache creation token counts alongside existing token usage attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->