### PR TITLE
fix: mirror Gemini thought_signature onto reasoning_details for OpenAI-compatible clients

### DIFF
--- a/src/endpoints/chat-completions/converters.test.ts
+++ b/src/endpoints/chat-completions/converters.test.ts
@@ -534,6 +534,44 @@ describe("Chat Completions Converters", () => {
       expect(content[0]!.type).toBe("tool-call");
     });
 
+    test("should emit reasoning part when id matches a tool call but format is not Gemini's envelope", () => {
+      // Guards the narrow correlation: only Gemini's thought-signature envelope
+      // (reasoning.encrypted + google-gemini-v1 + data) should be diverted into
+      // the tool call's providerOptions. Unrelated encrypted reasoning entries
+      // that happen to share an id with a tool call must still surface as a
+      // reasoning part.
+      const message = fromChatCompletionsAssistantMessage({
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "web_search", arguments: "{}" },
+          },
+        ],
+        reasoning_details: [
+          {
+            id: "call_1",
+            index: 0,
+            type: "reasoning.encrypted",
+            data: "other-provider-blob",
+            format: "unknown",
+          },
+        ],
+      });
+
+      const content = message.content as unknown as Array<{
+        type: string;
+        providerOptions?: Record<string, unknown>;
+      }>;
+      expect(content).toHaveLength(2);
+      expect(content[0]!.type).toBe("reasoning");
+      expect(content[1]!.type).toBe("tool-call");
+      // The tool call must not pick up the non-Gemini envelope as a signature.
+      expect(content[1]!.providerOptions).toBeUndefined();
+    });
+
     test("should still emit standalone reasoning parts when id does not match any tool call", () => {
       const message = fromChatCompletionsAssistantMessage({
         role: "assistant",

--- a/src/endpoints/chat-completions/converters.test.ts
+++ b/src/endpoints/chat-completions/converters.test.ts
@@ -1129,7 +1129,7 @@ describe("Chat Completions Converters", () => {
       for await (const frame of transformed as AsyncIterable<
         SseFrame<ChatCompletionsChunk> | SseErrorFrame
       >) {
-        if (frame.data instanceof Error) continue;
+        if (frame.data instanceof Error) throw frame.data;
         chunks.push(frame.data);
       }
       return chunks;
@@ -1198,6 +1198,12 @@ describe("Chat Completions Converters", () => {
       const chunks = await collectChunks(source);
 
       const reasoningChunk = chunks.find((c) => c.choices[0]?.delta.reasoning_details);
+      const toolCallChunk = chunks.find((c) => c.choices[0]?.delta.tool_calls);
+      expect(toolCallChunk).toBeDefined();
+      expect(toolCallChunk!.choices[0]!.delta.tool_calls![0]).toMatchObject({
+        id: "call_1",
+        index: 0,
+      });
       expect(reasoningChunk).toBeUndefined();
     });
   });

--- a/src/endpoints/chat-completions/converters.test.ts
+++ b/src/endpoints/chat-completions/converters.test.ts
@@ -8,9 +8,13 @@ import type {
   FilePart,
   LanguageModelUsage,
   AssistantModelMessage,
+  ToolCallPart,
 } from "ai";
 
+import type { TextStreamPart } from "ai";
+
 import {
+  ChatCompletionsTransformStream,
   convertToTextCallOptions,
   toChatCompletions,
   toChatCompletionsAssistantMessage,
@@ -19,7 +23,8 @@ import {
   fromChatCompletionsAssistantMessage,
   fromChatCompletionsToolResultMessage,
 } from "./converters";
-import type { ChatCompletionsToolMessage } from "./schema";
+import type { ChatCompletionsChunk, ChatCompletionsToolMessage } from "./schema";
+import type { SseErrorFrame, SseFrame } from "../../utils/stream";
 
 const mockUsage = (overrides: Partial<LanguageModelUsage> = {}): LanguageModelUsage =>
   ({
@@ -223,6 +228,59 @@ describe("Chat Completions Converters", () => {
       });
     });
 
+    test("should emit reasoning_details for tool calls carrying thought_signature", () => {
+      // OpenCode / @ai-sdk/openai-compatible strips our `extra_content`, so we
+      // also mirror Gemini's thought_signature onto the standard
+      // `reasoning_details` channel (keyed by tool_call.id) that these clients
+      // round-trip correctly — same approach as OpenRouter.
+      const mockResult = mockGenerateTextResult({
+        finishReason: "tool-calls",
+        toolCalls: [
+          {
+            type: "tool-call",
+            toolCallId: "call_123",
+            toolName: "get_weather",
+            input: { location: "London" },
+            providerMetadata: {
+              vertex: { thought_signature: "tool-sig" },
+            },
+          },
+        ],
+      });
+
+      const message = toChatCompletionsAssistantMessage(mockResult);
+
+      expect(message.tool_calls![0]!.extra_content).toEqual({
+        vertex: { thought_signature: "tool-sig" },
+      });
+      expect(message.reasoning_details).toHaveLength(1);
+      expect(message.reasoning_details![0]).toEqual({
+        id: "call_123",
+        index: 0,
+        type: "reasoning.encrypted",
+        data: "tool-sig",
+        format: "google-gemini-v1",
+      });
+    });
+
+    test("should not emit reasoning_details for tool calls without thought_signature", () => {
+      const mockResult = mockGenerateTextResult({
+        finishReason: "tool-calls",
+        toolCalls: [
+          {
+            type: "tool-call",
+            toolCallId: "call_123",
+            toolName: "get_weather",
+            input: { location: "London" },
+          },
+        ],
+      });
+
+      const message = toChatCompletionsAssistantMessage(mockResult);
+
+      expect(message.reasoning_details).toBeUndefined();
+    });
+
     test("should extract reasoning_details from reasoning parts", () => {
       const mockResult = mockGenerateTextResult({
         text: "Final answer.",
@@ -374,6 +432,127 @@ describe("Chat Completions Converters", () => {
         toolName: "my_tool",
         input: {},
       });
+    });
+
+    test("should reconstruct thought_signature from reasoning_details when extra_content is missing", () => {
+      // Clients like OpenCode / @ai-sdk/openai-compatible drop our custom
+      // extra_content field but round-trip reasoning_details. We rebuild the
+      // tool call's providerOptions from the paired reasoning entry (matched by
+      // id) so Vertex receives the signature Gemini requires on every turn.
+      const message = fromChatCompletionsAssistantMessage({
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: {
+              name: "web_search",
+              arguments: '{"q":"hi"}',
+            },
+          },
+        ],
+        reasoning_details: [
+          {
+            id: "call_1",
+            index: 0,
+            type: "reasoning.encrypted",
+            data: "sig-abc",
+            format: "google-gemini-v1",
+          },
+        ],
+      });
+
+      expect(Array.isArray(message.content)).toBe(true);
+      const content = message.content;
+      expect(content).toHaveLength(1);
+      expect(content[0]).toEqual({
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "web_search",
+        input: { q: "hi" },
+        providerOptions: { vertex: { thought_signature: "sig-abc" } },
+      });
+    });
+
+    test("should prefer extra_content over reasoning_details when both are present", () => {
+      const message = fromChatCompletionsAssistantMessage({
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: {
+              name: "web_search",
+              arguments: "{}",
+            },
+            extra_content: { vertex: { thought_signature: "from-extra" } },
+          },
+        ],
+        reasoning_details: [
+          {
+            id: "call_1",
+            index: 0,
+            type: "reasoning.encrypted",
+            data: "from-reasoning",
+            format: "google-gemini-v1",
+          },
+        ],
+      });
+
+      const content = message.content as unknown as ToolCallPart[];
+      expect(content[0]!.providerOptions).toEqual({
+        vertex: { thought_signature: "from-extra" },
+      });
+    });
+
+    test("should not duplicate tool-call-bound reasoning as standalone reasoning parts", () => {
+      const message = fromChatCompletionsAssistantMessage({
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "web_search", arguments: "{}" },
+          },
+        ],
+        reasoning_details: [
+          {
+            id: "call_1",
+            index: 0,
+            type: "reasoning.encrypted",
+            data: "sig-abc",
+            format: "google-gemini-v1",
+          },
+        ],
+      });
+
+      const content = message.content as unknown as Array<{ type: string }>;
+      expect(content).toHaveLength(1);
+      expect(content[0]!.type).toBe("tool-call");
+    });
+
+    test("should still emit standalone reasoning parts when id does not match any tool call", () => {
+      const message = fromChatCompletionsAssistantMessage({
+        role: "assistant",
+        content: "hi",
+        reasoning_details: [
+          {
+            id: "reasoning_1",
+            index: 0,
+            type: "reasoning.encrypted",
+            data: "thoughts",
+            format: "unknown",
+          },
+        ],
+      });
+
+      const content = message.content as unknown as Array<{ type: string }>;
+      expect(content).toHaveLength(2);
+      expect(content[0]!.type).toBe("reasoning");
+      expect(content[1]!.type).toBe("text");
     });
   });
 
@@ -899,6 +1078,89 @@ describe("Chat Completions Converters", () => {
       const call = toChatCompletionsToolCall("call_1", "a".repeat(200), {});
       expect(call.function.name).toHaveLength(128);
       expect(call.function.name).toBe("a".repeat(128));
+    });
+  });
+
+  describe("ChatCompletionsTransformStream", () => {
+    const collectChunks = async (
+      source: ReadableStream<TextStreamPart<ToolSet>>,
+    ): Promise<ChatCompletionsChunk[]> => {
+      const transformed = source.pipeThrough(new ChatCompletionsTransformStream("test-model"));
+      const chunks: ChatCompletionsChunk[] = [];
+      // oxlint-disable-next-line no-await-in-loop
+      for await (const frame of transformed as AsyncIterable<
+        SseFrame<ChatCompletionsChunk> | SseErrorFrame
+      >) {
+        if (frame.data instanceof Error) continue;
+        chunks.push(frame.data);
+      }
+      return chunks;
+    };
+
+    test("should emit reasoning_details before tool_calls when Gemini thought_signature is present", async () => {
+      const source = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "tool-call",
+            toolCallId: "call_gemini",
+            toolName: "web_search",
+            input: { q: "hi" },
+            providerMetadata: { vertex: { thought_signature: "stream-sig" } },
+          });
+          controller.enqueue({
+            type: "finish",
+            finishReason: "tool-calls",
+            rawFinishReason: "tool_calls",
+            totalUsage: mockUsage({ outputTokens: 5 }),
+          });
+          controller.close();
+        },
+      });
+
+      const chunks = await collectChunks(source);
+
+      const reasoningChunk = chunks.find((c) => c.choices[0]?.delta.reasoning_details);
+      const toolCallChunk = chunks.find((c) => c.choices[0]?.delta.tool_calls);
+
+      expect(reasoningChunk).toBeDefined();
+      expect(toolCallChunk).toBeDefined();
+      expect(chunks.indexOf(reasoningChunk!)).toBeLessThan(chunks.indexOf(toolCallChunk!));
+      expect(reasoningChunk!.choices[0]!.delta.reasoning_details![0]).toEqual({
+        id: "call_gemini",
+        index: 0,
+        type: "reasoning.encrypted",
+        data: "stream-sig",
+        format: "google-gemini-v1",
+      });
+      expect(toolCallChunk!.choices[0]!.delta.tool_calls![0]).toMatchObject({
+        id: "call_gemini",
+        index: 0,
+      });
+    });
+
+    test("should not emit reasoning_details chunk when tool call has no thought_signature", async () => {
+      const source = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "web_search",
+            input: { q: "hi" },
+          });
+          controller.enqueue({
+            type: "finish",
+            finishReason: "tool-calls",
+            rawFinishReason: "tool_calls",
+            totalUsage: mockUsage({ outputTokens: 5 }),
+          });
+          controller.close();
+        },
+      });
+
+      const chunks = await collectChunks(source);
+
+      const reasoningChunk = chunks.find((c) => c.choices[0]?.delta.reasoning_details);
+      expect(reasoningChunk).toBeUndefined();
     });
   });
 });

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -34,6 +34,7 @@ import {
   parseBase64,
   parseImageInput,
   extractReasoningMetadata,
+  extractThoughtSignature,
   type TextCallOptions,
   type ToolChoiceOptions,
 } from "../shared/converters";
@@ -201,8 +202,18 @@ export function fromChatCompletionsAssistantMessage(
 
   const parts: AssistantContent = [];
 
+  // Entries whose `id` matches a `tool_calls[i].id` are Gemini thought-signature
+  // envelopes — they bind to a tool call, not to chain-of-thought, so we hand
+  // them to the tool_calls loop instead of turning them into reasoning parts.
+  const toolCallIds = new Set(tool_calls?.map((tc) => tc.id) ?? []);
+  const toolCallReasoningById = new Map<string, ChatCompletionsReasoningDetail>();
+
   if (reasoning_details?.length) {
     for (const detail of reasoning_details) {
+      if (detail.id && toolCallIds.has(detail.id)) {
+        toolCallReasoningById.set(detail.id, detail);
+        continue;
+      }
       if (detail.text && detail.type === "reasoning.text") {
         parts.push({
           type: "reasoning",
@@ -262,6 +273,15 @@ export function fromChatCompletionsAssistantMessage(
       };
       if (extra_content) {
         out.providerOptions = extra_content;
+      } else {
+        // Fall back to the paired reasoning_details entry (OpenRouter/Vercel
+        // convention) when the client stripped our extra_content. Gemini needs
+        // every follow-up turn to echo `thought_signature` on each function-call
+        // part or Vertex rejects the request.
+        const reasoning = toolCallReasoningById.get(id);
+        if (reasoning?.type === "reasoning.encrypted" && reasoning.data) {
+          out.providerOptions = { vertex: { thought_signature: reasoning.data } };
+        }
       }
       parts.push(out);
     }
@@ -595,6 +615,19 @@ export class ChatCompletionsTransformStream extends TransformStream<
           }
 
           case "tool-call": {
+            const signature = extractThoughtSignature(part.providerMetadata);
+            if (signature) {
+              const index = reasoningIdToIndex.size;
+              reasoningIdToIndex.set(part.toolCallId, index);
+              controller.enqueue(
+                createChunk({
+                  reasoning_details: [
+                    toToolCallReasoningDetail(part.toolCallId, signature, index),
+                  ],
+                }),
+              );
+            }
+
             const toolCall = toChatCompletionsToolCall(
               part.toolCallId,
               part.toolName,
@@ -676,6 +709,17 @@ export const toChatCompletionsAssistantMessage = (
     }
   }
 
+  if (result.toolCalls) {
+    for (const toolCall of result.toolCalls) {
+      const signature = extractThoughtSignature(toolCall.providerMetadata);
+      if (signature) {
+        reasoningDetails.push(
+          toToolCallReasoningDetail(toolCall.toolCallId, signature, reasoningDetails.length),
+        );
+      }
+    }
+  }
+
   if (result.reasoningText) {
     message.reasoning = result.reasoningText;
   }
@@ -691,6 +735,25 @@ export const toChatCompletionsAssistantMessage = (
 
   return message;
 };
+
+// Mirrors OpenRouter's chat-completions convention for Gemini thought signatures:
+// emit an encrypted reasoning detail whose `id` matches the tool call's `id` so
+// OpenAI-compatible clients (e.g. @ai-sdk/openai-compatible) round-trip the
+// signature on the next turn via `reasoning_details[]` rather than the
+// non-standard `tool_calls[i].extra_content` field they tend to strip.
+export function toToolCallReasoningDetail(
+  toolCallId: string,
+  signature: string,
+  index: number,
+): ChatCompletionsReasoningDetail {
+  return {
+    id: toolCallId,
+    index,
+    type: "reasoning.encrypted",
+    data: signature,
+    format: "google-gemini-v1",
+  };
+}
 
 export function toReasoningDetail(
   reasoning: ReasoningOutput,

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -210,7 +210,16 @@ export function fromChatCompletionsAssistantMessage(
 
   if (reasoning_details?.length) {
     for (const detail of reasoning_details) {
-      if (detail.id && toolCallIds.has(detail.id)) {
+      // Only divert entries that match our Gemini thought-signature envelope
+      // (type=reasoning.encrypted, format=google-gemini-v1, with data). Looser
+      // id-only matching would drop unrelated reasoning entries on id collision.
+      if (
+        detail.id &&
+        toolCallIds.has(detail.id) &&
+        detail.type === "reasoning.encrypted" &&
+        detail.format === "google-gemini-v1" &&
+        typeof detail.data === "string"
+      ) {
         toolCallReasoningById.set(detail.id, detail);
         continue;
       }

--- a/src/endpoints/shared/converters.ts
+++ b/src/endpoints/shared/converters.ts
@@ -228,6 +228,21 @@ export function stripEmptyKeys(obj: unknown) {
   return obj;
 }
 
+export function extractThoughtSignature(
+  providerMetadata?: SharedV3ProviderMetadata,
+): string | undefined {
+  if (!providerMetadata) return undefined;
+
+  for (const metadata of Object.values(providerMetadata)) {
+    if (metadata && typeof metadata === "object") {
+      const value = (metadata as Record<string, unknown>)["thought_signature"];
+      if (typeof value === "string") return value;
+    }
+  }
+
+  return undefined;
+}
+
 export function extractReasoningMetadata(providerMetadata?: SharedV3ProviderMetadata): {
   redactedData?: string;
   signature?: string;


### PR DESCRIPTION
## Summary
- Mirror Gemini`s `thought_signature` onto the standard `reasoning_details` channel on `/chat/completions` (match OpenRouter/Vercel convention) so OpenAI-compatible clients round-trip it instead of dropping our custom `extra_content` field.
- Reconstruct `providerOptions.vertex.thought_signature` on the request side from `reasoning_details` when `extra_content` is absent, keyed by the shared `id` between each entry and its `tool_call`.
- `extra_content` still wins when both are present (no regression for Gemini-aware clients).
- Emit the streaming `reasoning_details` chunk before the `tool_calls` chunk to match OpenRouter`s SSE ordering.

Fixes #172

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` (626 pass)
- [x] `bun run lint`
- [x] `bun run build`
- [ ] Manual verification with OpenCode + Hebo Gateway + Gemini (tool use round-trip)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for Gemini thought-signature behavior in chat completions, covering streaming and non‑streaming flows and the presence/absence cases and emission ordering.

* **Improvements**
  * Better handling of encrypted Gemini reasoning signatures tied to tool results, ensuring signatures are preserved, backfilled into tool outputs when missing, and excluded from normal reasoning rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->