### PR TITLE
fix: include cache tokens in /v1/messages streaming message_delta usage

### DIFF
--- a/src/endpoints/messages/converters.test.ts
+++ b/src/endpoints/messages/converters.test.ts
@@ -1150,6 +1150,43 @@ describe("Messages Converters", () => {
       expect(messageStop).toBeDefined();
     });
 
+    test("should include cache tokens in streaming message_delta usage", async () => {
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({ type: "text-start", id: "1" });
+          controller.enqueue({ type: "text-delta", id: "1", text: "ok" });
+          controller.enqueue({ type: "text-end", id: "1" });
+          controller.enqueue({
+            type: "finish",
+            finishReason: "stop",
+            rawFinishReason: "stop",
+            totalUsage: mockUsage({
+              inputTokens: 16816,
+              outputTokens: 1,
+              inputTokenDetails: {
+                cacheReadTokens: 0,
+                cacheWriteTokens: 16813,
+                noCacheTokens: undefined,
+              },
+            }),
+          });
+          controller.close();
+        },
+      });
+
+      const transformed = stream.pipeThrough(new MessagesTransformStream("test-model"));
+      const { events } = await collectStreamEvents(transformed);
+
+      const messageDelta = events.find((e) => e.event === "message_delta");
+      expect(messageDelta).toBeDefined();
+      if (messageDelta?.event === "message_delta") {
+        expect(messageDelta.data.usage.input_tokens).toBe(16816);
+        expect(messageDelta.data.usage.output_tokens).toBe(1);
+        expect(messageDelta.data.usage.cache_creation_input_tokens).toBe(16813);
+        expect(messageDelta.data.usage.cache_read_input_tokens).toBe(0);
+      }
+    });
+
     test("should stream tool call events correctly", async () => {
       const stream = new ReadableStream<TextStreamPart<ToolSet>>({
         start(controller) {

--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -767,15 +767,13 @@ export class MessagesTransformStream extends TransformStream<
 
           case "finish": {
             const stopReason = mapStopReason(part.finishReason);
-            const totalOutputTokens = part.totalUsage?.outputTokens ?? 0;
-            const totalInputTokens = part.totalUsage?.inputTokens ?? 0;
 
             controller.enqueue({
               event: "message_delta",
               data: {
                 type: "message_delta",
                 delta: { stop_reason: stopReason, stop_sequence: null },
-                usage: { output_tokens: totalOutputTokens, input_tokens: totalInputTokens },
+                usage: mapUsage(part.totalUsage),
               },
             });
 

--- a/src/endpoints/messages/schema.ts
+++ b/src/endpoints/messages/schema.ts
@@ -342,7 +342,7 @@ export type MessageDeltaEvent = SseFrame<
   {
     type: "message_delta";
     delta: { stop_reason: MessagesStopReason; stop_sequence: string | null };
-    usage: { output_tokens: number; input_tokens?: number };
+    usage: MessagesUsage;
   },
   "message_delta"
 >;


### PR DESCRIPTION
## Summary
- Route streaming `message_delta` usage through `mapUsage` so `cache_read_input_tokens` and `cache_creation_input_tokens` reach SSE clients, matching the non-streaming response and OTEL span.
- Widen `MessageDeltaEvent.usage` to `MessagesUsage` so the cache fields are first-class in the type layer.
- Add a streaming test covering `cache_creation_input_tokens` / `cache_read_input_tokens` in `message_delta`.

Fixes #187.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (619 pass)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message delta events to properly propagate cached token accounting (`cache_creation_input_tokens` and `cache_read_input_tokens`) in streaming responses.

* **Tests**
  * Added test coverage for cached token propagation in streamed message deltas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->