### PR TITLE
align gen_ai.client.token.usage with OTel semconv PR #3624

### DIFF
--- a/src/telemetry/gen-ai.test.ts
+++ b/src/telemetry/gen-ai.test.ts
@@ -1,0 +1,220 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+
+import { metrics } from "@opentelemetry/api";
+import {
+  AggregationTemporality,
+  DataPointType,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+  type HistogramMetricData,
+} from "@opentelemetry/sdk-metrics";
+
+import { recordTokenUsage } from "./gen-ai";
+
+type Point = {
+  value: number;
+  attributes: Record<string, unknown>;
+};
+
+let exporter: InMemoryMetricExporter;
+let reader: PeriodicExportingMetricReader;
+let provider: MeterProvider;
+
+const collectTokenUsagePoints = async (): Promise<Point[]> => {
+  await reader.forceFlush();
+  const histograms: HistogramMetricData[] = [];
+  for (const rm of exporter.getMetrics()) {
+    for (const sm of rm.scopeMetrics) {
+      for (const metric of sm.metrics) {
+        if (
+          metric.descriptor.name === "gen_ai.client.token.usage" &&
+          metric.dataPointType === DataPointType.HISTOGRAM
+        ) {
+          histograms.push(metric);
+        }
+      }
+    }
+  }
+  return histograms.flatMap((h) =>
+    h.dataPoints
+      .filter((dp) => (dp.value.count ?? 0) > 0)
+      .map((dp) => ({ value: dp.value.sum ?? 0, attributes: { ...dp.attributes } })),
+  );
+};
+
+describe("recordTokenUsage", () => {
+  beforeAll(() => {
+    exporter = new InMemoryMetricExporter(AggregationTemporality.DELTA);
+    reader = new PeriodicExportingMetricReader({
+      exporter,
+      exportIntervalMillis: 60_000,
+      exportTimeoutMillis: 10_000,
+    });
+    provider = new MeterProvider({ readers: [reader] });
+    metrics.setGlobalMeterProvider(provider);
+  });
+
+  afterAll(async () => {
+    await provider.shutdown();
+    metrics.disable();
+  });
+
+  afterEach(() => {
+    exporter.reset();
+  });
+
+  test("emits single {type} points when no breakdown is reported", async () => {
+    recordTokenUsage(
+      {
+        "gen_ai.usage.input_tokens": 100,
+        "gen_ai.usage.output_tokens": 50,
+      },
+      { "gen_ai.request.model": "m" },
+      "recommended",
+    );
+
+    const points = await collectTokenUsagePoints();
+
+    expect(points).toHaveLength(2);
+    expect(points).toContainEqual({
+      value: 100,
+      attributes: { "gen_ai.request.model": "m", "gen_ai.token.type": "input" },
+    });
+    expect(points).toContainEqual({
+      value: 50,
+      attributes: { "gen_ai.request.model": "m", "gen_ai.token.type": "output" },
+    });
+  });
+
+  test("partitions input across cache=read|creation|uncached and does not emit bare input point", async () => {
+    recordTokenUsage(
+      {
+        "gen_ai.usage.input_tokens": 100,
+        "gen_ai.usage.cache_read.input_tokens": 30,
+        "gen_ai.usage.cache_creation.input_tokens": 20,
+        "gen_ai.usage.output_tokens": 200,
+      },
+      {},
+      "recommended",
+    );
+
+    const points = await collectTokenUsagePoints();
+
+    const inputPoints = points.filter((p) => p.attributes["gen_ai.token.type"] === "input");
+    expect(inputPoints).toHaveLength(3);
+    expect(inputPoints).toContainEqual({
+      value: 30,
+      attributes: { "gen_ai.token.type": "input", "gen_ai.token.cache": "read" },
+    });
+    expect(inputPoints).toContainEqual({
+      value: 20,
+      attributes: { "gen_ai.token.type": "input", "gen_ai.token.cache": "creation" },
+    });
+    expect(inputPoints).toContainEqual({
+      value: 50,
+      attributes: { "gen_ai.token.type": "input", "gen_ai.token.cache": "uncached" },
+    });
+    const inputSum = inputPoints.reduce((sum, p) => sum + p.value, 0);
+    expect(inputSum).toBe(100);
+    expect(inputPoints.some((p) => p.attributes["gen_ai.token.cache"] === undefined)).toBe(false);
+  });
+
+  test("partitions output by reasoning=true|false and does not emit bare output point", async () => {
+    recordTokenUsage(
+      {
+        "gen_ai.usage.input_tokens": 10,
+        "gen_ai.usage.output_tokens": 200,
+        "gen_ai.usage.reasoning.output_tokens": 150,
+      },
+      {},
+      "recommended",
+    );
+
+    const points = await collectTokenUsagePoints();
+
+    const outputPoints = points.filter((p) => p.attributes["gen_ai.token.type"] === "output");
+    expect(outputPoints).toHaveLength(2);
+    expect(outputPoints).toContainEqual({
+      value: 150,
+      attributes: { "gen_ai.token.type": "output", "gen_ai.token.reasoning": true },
+    });
+    expect(outputPoints).toContainEqual({
+      value: 50,
+      attributes: { "gen_ai.token.type": "output", "gen_ai.token.reasoning": false },
+    });
+    expect(outputPoints.some((p) => p.attributes["gen_ai.token.reasoning"] === undefined)).toBe(
+      false,
+    );
+  });
+
+  test("omits zero-valued partition members", async () => {
+    recordTokenUsage(
+      {
+        "gen_ai.usage.input_tokens": 100,
+        "gen_ai.usage.cache_read.input_tokens": 100,
+        "gen_ai.usage.cache_creation.input_tokens": 0,
+        "gen_ai.usage.output_tokens": 50,
+        "gen_ai.usage.reasoning.output_tokens": 50,
+      },
+      {},
+      "recommended",
+    );
+
+    const points = await collectTokenUsagePoints();
+
+    const inputPoints = points.filter((p) => p.attributes["gen_ai.token.type"] === "input");
+    expect(inputPoints).toHaveLength(1);
+    expect(inputPoints[0]).toEqual({
+      value: 100,
+      attributes: { "gen_ai.token.type": "input", "gen_ai.token.cache": "read" },
+    });
+
+    const outputPoints = points.filter((p) => p.attributes["gen_ai.token.type"] === "output");
+    expect(outputPoints).toHaveLength(1);
+    expect(outputPoints[0]).toEqual({
+      value: 50,
+      attributes: { "gen_ai.token.type": "output", "gen_ai.token.reasoning": true },
+    });
+  });
+
+  test("clamps negative uncached to zero when cache partitions exceed total", async () => {
+    recordTokenUsage(
+      {
+        "gen_ai.usage.input_tokens": 50,
+        "gen_ai.usage.cache_read.input_tokens": 40,
+        "gen_ai.usage.cache_creation.input_tokens": 20,
+      },
+      {},
+      "recommended",
+    );
+
+    const points = await collectTokenUsagePoints();
+
+    const inputPoints = points.filter((p) => p.attributes["gen_ai.token.type"] === "input");
+    expect(inputPoints).toHaveLength(2);
+    expect(inputPoints.some((p) => p.attributes["gen_ai.token.cache"] === "uncached")).toBe(false);
+  });
+
+  test("does nothing for off/required signal level", async () => {
+    recordTokenUsage(
+      {
+        "gen_ai.usage.input_tokens": 100,
+        "gen_ai.usage.output_tokens": 50,
+      },
+      {},
+      "off",
+    );
+    recordTokenUsage(
+      {
+        "gen_ai.usage.input_tokens": 100,
+        "gen_ai.usage.output_tokens": 50,
+      },
+      {},
+      "required",
+    );
+
+    const points = await collectTokenUsagePoints();
+    expect(points).toHaveLength(0);
+  });
+});

--- a/src/telemetry/gen-ai.ts
+++ b/src/telemetry/gen-ai.ts
@@ -1,9 +1,4 @@
-import {
-  metrics,
-  type AttributeValue,
-  type Attributes,
-  type Histogram,
-} from "@opentelemetry/api";
+import { metrics, type Attributes, type Histogram } from "@opentelemetry/api";
 
 import { STATUS_TEXT } from "../errors/utils";
 import { logger } from "../logger";
@@ -145,9 +140,6 @@ export const recordTimePerOutputToken = (
   );
 };
 
-const asNum = (v: AttributeValue | undefined): number | undefined =>
-  typeof v === "number" ? v : undefined;
-
 // Partitioning follows OTel semconv PR #3624:
 // https://github.com/open-telemetry/semantic-conventions/pull/3624
 // When a cache or reasoning breakdown is reported, partitioned data points sum
@@ -172,11 +164,13 @@ export const recordTokenUsage = (
 type Emit = (value: number, extra: Attributes) => void;
 
 const emitInputTokens = (emit: Emit, tokenAttrs: Attributes) => {
-  const total = asNum(tokenAttrs["gen_ai.usage.input_tokens"]);
+  const total = tokenAttrs["gen_ai.usage.input_tokens"] as number | undefined;
   if (total === undefined) return;
 
-  const cacheRead = asNum(tokenAttrs["gen_ai.usage.cache_read.input_tokens"]);
-  const cacheCreation = asNum(tokenAttrs["gen_ai.usage.cache_creation.input_tokens"]);
+  const cacheRead = tokenAttrs["gen_ai.usage.cache_read.input_tokens"] as number | undefined;
+  const cacheCreation = tokenAttrs["gen_ai.usage.cache_creation.input_tokens"] as
+    | number
+    | undefined;
   if (cacheRead === undefined && cacheCreation === undefined) {
     emit(total, { "gen_ai.token.type": "input" });
     return;
@@ -198,10 +192,10 @@ const emitInputTokens = (emit: Emit, tokenAttrs: Attributes) => {
 };
 
 const emitOutputTokens = (emit: Emit, tokenAttrs: Attributes) => {
-  const total = asNum(tokenAttrs["gen_ai.usage.output_tokens"]);
+  const total = tokenAttrs["gen_ai.usage.output_tokens"] as number | undefined;
   if (total === undefined) return;
 
-  const reasoning = asNum(tokenAttrs["gen_ai.usage.reasoning.output_tokens"]);
+  const reasoning = tokenAttrs["gen_ai.usage.reasoning.output_tokens"] as number | undefined;
   if (reasoning === undefined) {
     emit(total, { "gen_ai.token.type": "output" });
     return;

--- a/src/telemetry/gen-ai.ts
+++ b/src/telemetry/gen-ai.ts
@@ -1,4 +1,9 @@
-import { metrics, type Attributes, type Histogram } from "@opentelemetry/api";
+import {
+  metrics,
+  type AttributeValue,
+  type Attributes,
+  type Histogram,
+} from "@opentelemetry/api";
 
 import { STATUS_TEXT } from "../errors/utils";
 import { logger } from "../logger";
@@ -140,6 +145,9 @@ export const recordTimePerOutputToken = (
   );
 };
 
+const asNum = (v: AttributeValue | undefined): number | undefined =>
+  typeof v === "number" ? v : undefined;
+
 // Partitioning follows OTel semconv PR #3624:
 // https://github.com/open-telemetry/semantic-conventions/pull/3624
 // When a cache or reasoning breakdown is reported, partitioned data points sum
@@ -150,61 +158,65 @@ export const recordTokenUsage = (
   metricAttrs: Attributes,
   signalLevel?: TelemetrySignalLevel,
 ) => {
-  if (!signalLevel || (signalLevel !== "recommended" && signalLevel !== "full")) return;
+  if (signalLevel !== "recommended" && signalLevel !== "full") return;
 
   const histogram = getTokenUsageHistogram();
-  const record = (value: number, extra: Attributes) => {
-    histogram.record(value, Object.assign({}, metricAttrs, extra));
+  const emit = (value: number, extra: Attributes) => {
+    if (value > 0) histogram.record(value, { ...metricAttrs, ...extra });
   };
 
-  const inputTokens = tokenAttrs["gen_ai.usage.input_tokens"];
-  if (typeof inputTokens === "number") {
-    const cacheRead = tokenAttrs["gen_ai.usage.cache_read.input_tokens"];
-    const cacheCreation = tokenAttrs["gen_ai.usage.cache_creation.input_tokens"];
-    const hasCacheRead = typeof cacheRead === "number";
-    const hasCacheCreation = typeof cacheCreation === "number";
+  emitInputTokens(emit, tokenAttrs);
+  emitOutputTokens(emit, tokenAttrs);
+};
 
-    if (hasCacheRead || hasCacheCreation) {
-      const read = hasCacheRead ? cacheRead : 0;
-      const creation = hasCacheCreation ? cacheCreation : 0;
-      let uncached = inputTokens - read - creation;
-      if (uncached < 0) {
-        logger.warn(
-          { inputTokens, cacheRead: read, cacheCreation: creation },
-          "[telemetry] input token cache partitions exceed total; clamping uncached to 0",
-        );
-        uncached = 0;
-      }
-      if (read > 0) record(read, { "gen_ai.token.type": "input", "gen_ai.token.cache": "read" });
-      if (creation > 0)
-        record(creation, { "gen_ai.token.type": "input", "gen_ai.token.cache": "creation" });
-      if (uncached > 0)
-        record(uncached, { "gen_ai.token.type": "input", "gen_ai.token.cache": "uncached" });
-    } else {
-      record(inputTokens, { "gen_ai.token.type": "input" });
-    }
+type Emit = (value: number, extra: Attributes) => void;
+
+const emitInputTokens = (emit: Emit, tokenAttrs: Attributes) => {
+  const total = asNum(tokenAttrs["gen_ai.usage.input_tokens"]);
+  if (total === undefined) return;
+
+  const cacheRead = asNum(tokenAttrs["gen_ai.usage.cache_read.input_tokens"]);
+  const cacheCreation = asNum(tokenAttrs["gen_ai.usage.cache_creation.input_tokens"]);
+  if (cacheRead === undefined && cacheCreation === undefined) {
+    emit(total, { "gen_ai.token.type": "input" });
+    return;
   }
 
-  const outputTokens = tokenAttrs["gen_ai.usage.output_tokens"];
-  if (typeof outputTokens === "number") {
-    const reasoning = tokenAttrs["gen_ai.usage.reasoning.output_tokens"];
-    if (typeof reasoning === "number") {
-      let reasoned = reasoning;
-      let nonReasoning = outputTokens - reasoning;
-      if (nonReasoning < 0) {
-        logger.warn(
-          { outputTokens, reasoningTokens: reasoning },
-          "[telemetry] reasoning tokens exceed output total; clamping non-reasoning to 0",
-        );
-        reasoned = outputTokens;
-        nonReasoning = 0;
-      }
-      if (reasoned > 0)
-        record(reasoned, { "gen_ai.token.type": "output", "gen_ai.token.reasoning": true });
-      if (nonReasoning > 0)
-        record(nonReasoning, { "gen_ai.token.type": "output", "gen_ai.token.reasoning": false });
-    } else {
-      record(outputTokens, { "gen_ai.token.type": "output" });
-    }
+  const read = cacheRead ?? 0;
+  const creation = cacheCreation ?? 0;
+  let uncached = total - read - creation;
+  if (uncached < 0) {
+    logger.warn(
+      { inputTokens: total, cacheRead: read, cacheCreation: creation },
+      "[telemetry] input token cache partitions exceed total; clamping uncached to 0",
+    );
+    uncached = 0;
   }
+  emit(read, { "gen_ai.token.type": "input", "gen_ai.token.cache": "read" });
+  emit(creation, { "gen_ai.token.type": "input", "gen_ai.token.cache": "creation" });
+  emit(uncached, { "gen_ai.token.type": "input", "gen_ai.token.cache": "uncached" });
+};
+
+const emitOutputTokens = (emit: Emit, tokenAttrs: Attributes) => {
+  const total = asNum(tokenAttrs["gen_ai.usage.output_tokens"]);
+  if (total === undefined) return;
+
+  const reasoning = asNum(tokenAttrs["gen_ai.usage.reasoning.output_tokens"]);
+  if (reasoning === undefined) {
+    emit(total, { "gen_ai.token.type": "output" });
+    return;
+  }
+
+  let reasoned = reasoning;
+  let nonReasoning = total - reasoning;
+  if (nonReasoning < 0) {
+    logger.warn(
+      { outputTokens: total, reasoningTokens: reasoning },
+      "[telemetry] reasoning tokens exceed output total; clamping non-reasoning to 0",
+    );
+    reasoned = total;
+    nonReasoning = 0;
+  }
+  emit(reasoned, { "gen_ai.token.type": "output", "gen_ai.token.reasoning": true });
+  emit(nonReasoning, { "gen_ai.token.type": "output", "gen_ai.token.reasoning": false });
 };

--- a/src/telemetry/gen-ai.ts
+++ b/src/telemetry/gen-ai.ts
@@ -1,6 +1,7 @@
 import { metrics, type Attributes, type Histogram } from "@opentelemetry/api";
 
 import { STATUS_TEXT } from "../errors/utils";
+import { logger } from "../logger";
 import type { GatewayContext, TelemetrySignalLevel } from "../types";
 
 const getMeter = () => metrics.getMeter("@hebo/gateway");
@@ -139,6 +140,10 @@ export const recordTimePerOutputToken = (
   );
 };
 
+// Partitioning follows OTel semconv PR #3624:
+// https://github.com/open-telemetry/semantic-conventions/pull/3624
+// When a cache or reasoning breakdown is reported, partitioned data points sum
+// to the total and a bare {type} point MUST NOT be emitted alongside them.
 // FUTURE: record unsuccessful calls
 export const recordTokenUsage = (
   tokenAttrs: Attributes,
@@ -147,19 +152,59 @@ export const recordTokenUsage = (
 ) => {
   if (!signalLevel || (signalLevel !== "recommended" && signalLevel !== "full")) return;
 
-  const record = (value: unknown, tokenType: string) => {
-    if (typeof value !== "number") return;
-    getTokenUsageHistogram().record(
-      value,
-      Object.assign({}, metricAttrs, { "gen_ai.token.type": tokenType }),
-    );
+  const histogram = getTokenUsageHistogram();
+  const record = (value: number, extra: Attributes) => {
+    histogram.record(value, Object.assign({}, metricAttrs, extra));
   };
 
-  record(tokenAttrs["gen_ai.usage.input_tokens"], "input");
-  record(tokenAttrs["gen_ai.usage.output_tokens"], "output");
-  // FUTURE: "cached" and "reasoning" token types are not yet in the OTel standard — monitor:
-  // https://github.com/open-telemetry/semantic-conventions/issues/1959
-  // https://github.com/open-telemetry/semantic-conventions/issues/3341
-  record(tokenAttrs["gen_ai.usage.cache_read.input_tokens"], "cached");
-  record(tokenAttrs["gen_ai.usage.reasoning.output_tokens"], "reasoning");
+  const inputTokens = tokenAttrs["gen_ai.usage.input_tokens"];
+  if (typeof inputTokens === "number") {
+    const cacheRead = tokenAttrs["gen_ai.usage.cache_read.input_tokens"];
+    const cacheCreation = tokenAttrs["gen_ai.usage.cache_creation.input_tokens"];
+    const hasCacheRead = typeof cacheRead === "number";
+    const hasCacheCreation = typeof cacheCreation === "number";
+
+    if (hasCacheRead || hasCacheCreation) {
+      const read = hasCacheRead ? cacheRead : 0;
+      const creation = hasCacheCreation ? cacheCreation : 0;
+      let uncached = inputTokens - read - creation;
+      if (uncached < 0) {
+        logger.warn(
+          { inputTokens, cacheRead: read, cacheCreation: creation },
+          "[telemetry] input token cache partitions exceed total; clamping uncached to 0",
+        );
+        uncached = 0;
+      }
+      if (read > 0) record(read, { "gen_ai.token.type": "input", "gen_ai.token.cache": "read" });
+      if (creation > 0)
+        record(creation, { "gen_ai.token.type": "input", "gen_ai.token.cache": "creation" });
+      if (uncached > 0)
+        record(uncached, { "gen_ai.token.type": "input", "gen_ai.token.cache": "uncached" });
+    } else {
+      record(inputTokens, { "gen_ai.token.type": "input" });
+    }
+  }
+
+  const outputTokens = tokenAttrs["gen_ai.usage.output_tokens"];
+  if (typeof outputTokens === "number") {
+    const reasoning = tokenAttrs["gen_ai.usage.reasoning.output_tokens"];
+    if (typeof reasoning === "number") {
+      let reasoned = reasoning;
+      let nonReasoning = outputTokens - reasoning;
+      if (nonReasoning < 0) {
+        logger.warn(
+          { outputTokens, reasoningTokens: reasoning },
+          "[telemetry] reasoning tokens exceed output total; clamping non-reasoning to 0",
+        );
+        reasoned = outputTokens;
+        nonReasoning = 0;
+      }
+      if (reasoned > 0)
+        record(reasoned, { "gen_ai.token.type": "output", "gen_ai.token.reasoning": true });
+      if (nonReasoning > 0)
+        record(nonReasoning, { "gen_ai.token.type": "output", "gen_ai.token.reasoning": false });
+    } else {
+      record(outputTokens, { "gen_ai.token.type": "output" });
+    }
+  }
 };


### PR DESCRIPTION
Closes #185.

## Summary

Rewrites `recordTokenUsage` in `src/telemetry/gen-ai.ts` to follow the partition model proposed in [OTel semconv PR #3624](https://github.com/open-telemetry/semantic-conventions/pull/3624):

- Input tokens partition across `gen_ai.token.cache=read|creation|uncached` when any cache breakdown is reported; otherwise a single `{type=input}` data point.
- Output tokens partition across `gen_ai.token.reasoning=true|false` when reasoning tokens are reported; otherwise a single `{type=output}` data point.
- Bare `{type}` data points are never emitted alongside partitions.
- Zero-valued partition members are omitted.
- `uncached` is clamped to 0 (with a warn log) if cache partitions exceed input total.

## Breaking change

Dashboards querying `gen_ai.token.type="cached"` or `"reasoning"` will stop returning data. Migrate to `gen_ai.token.cache` / `gen_ai.token.reasoning`.

The new attributes are at OTel `development` stability; PR #3624 is open/unmerged and the enum values could still shift.

## Test plan

- [x] New unit tests in `src/telemetry/gen-ai.test.ts` exercise the partition rules via a real `MeterProvider` + `InMemoryMetricExporter`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 624 pass, 0 fail

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite for token usage telemetry tracking.

* **Chores**
  * Enhanced token usage metric collection to better partition cache efficiency and reasoning token data for improved monitoring visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->