### PR TITLE
feat: ensure service tier always has a value in telemetry (#196)

### DIFF
--- a/src/endpoints/messages/otel.test.ts
+++ b/src/endpoints/messages/otel.test.ts
@@ -43,7 +43,6 @@ describe("Messages OTEL", () => {
     expect(attrs["gen_ai.request.max_tokens"]).toBe(500);
     expect(attrs["gen_ai.request.temperature"]).toBe(0.7);
     expect(attrs["gen_ai.request.top_p"]).toBe(0.9);
-    expect(attrs["gen_ai.request.service_tier"]).toBe("auto");
   });
 
   test("should map request metadata into per-key attributes", () => {

--- a/src/endpoints/messages/otel.ts
+++ b/src/endpoints/messages/otel.ts
@@ -123,7 +123,6 @@ export const getMessagesRequestAttributes = (
   if (signalLevel !== "required") {
     Object.assign(attrs, {
       "gen_ai.request.stream": body.stream,
-      "gen_ai.request.service_tier": body.service_tier,
       "gen_ai.request.max_tokens": body.max_tokens,
       "gen_ai.request.temperature": body.temperature,
       "gen_ai.request.top_p": body.top_p,

--- a/src/telemetry/gen-ai.test.ts
+++ b/src/telemetry/gen-ai.test.ts
@@ -10,7 +10,8 @@ import {
   type HistogramMetricData,
 } from "@opentelemetry/sdk-metrics";
 
-import { recordTokenUsage } from "./gen-ai";
+import type { GatewayContext } from "../types";
+import { getGenAiGeneralAttributes, recordTokenUsage } from "./gen-ai";
 
 type Point = {
   value: number;
@@ -216,5 +217,39 @@ describe("recordTokenUsage", () => {
 
     const points = await collectTokenUsagePoints();
     expect(points).toHaveLength(0);
+  });
+});
+
+describe("getGenAiGeneralAttributes", () => {
+  const baseCtx = {
+    state: {},
+    otel: {},
+    providers: {} as GatewayContext["providers"],
+    models: {} as GatewayContext["models"],
+    request: new Request("https://example.test/"),
+    requestId: "req_1",
+    body: { model: "m" } as GatewayContext["body"],
+    operation: "chat" as GatewayContext["operation"],
+    resolvedModelId: "m",
+    resolvedProviderId: "p",
+  } satisfies GatewayContext;
+
+  test("defaults service_tier to 'auto' when the request body omits it", () => {
+    const attrs = getGenAiGeneralAttributes(baseCtx, "recommended");
+    expect(attrs["gen_ai.request.service_tier"]).toBe("auto");
+  });
+
+  test("emits the requested service_tier when the body provides one", () => {
+    const ctx: GatewayContext = {
+      ...baseCtx,
+      body: { ...baseCtx.body, service_tier: "priority" } as GatewayContext["body"],
+    };
+    const attrs = getGenAiGeneralAttributes(ctx, "recommended");
+    expect(attrs["gen_ai.request.service_tier"]).toBe("priority");
+  });
+
+  test("omits service_tier at 'required' signal level", () => {
+    const attrs = getGenAiGeneralAttributes(baseCtx, "required");
+    expect(attrs["gen_ai.request.service_tier"]).toBeUndefined();
   });
 });

--- a/src/telemetry/gen-ai.ts
+++ b/src/telemetry/gen-ai.ts
@@ -74,8 +74,7 @@ export const getGenAiGeneralAttributes = (
   if (!signalLevel || signalLevel === "off") return {};
 
   const requestModel = typeof ctx.body?.model === "string" ? ctx.body.model : ctx.modelId;
-  const serviceTier =
-    typeof ctx.body?.service_tier === "string" ? ctx.body.service_tier : undefined;
+  const serviceTier = typeof ctx.body?.service_tier === "string" ? ctx.body.service_tier : "auto";
 
   const attrs: Attributes = {
     "gen_ai.operation.name": ctx.operation,
@@ -84,7 +83,7 @@ export const getGenAiGeneralAttributes = (
     "gen_ai.provider.name": ctx.resolvedProviderId,
   };
 
-  if (signalLevel !== "required" && serviceTier !== undefined) {
+  if (signalLevel !== "required") {
     attrs["gen_ai.request.service_tier"] = serviceTier;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry by defaulting service tier to "auto" when not explicitly provided.

* **Refactor**
  * Reorganized service tier telemetry attribute generation logic for better consistency.

* **Tests**
  * Updated telemetry tests to validate service tier fallback behavior across different signal levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->