### PR TITLE
feat: add Grok 4.3 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Out-of-the-box model presets:
   Voyage: `voyage` (`v2`, `v3`, `v3.5`, `v4`, `v2.x`, `v3.x`, `v4.x`, `latest`, `all`)
 
 - **xAI** — `@hebo-ai/gateway/models/xai`  
-  Grok: `grok` (`v4.1`, `v4.2`, `latest`, `all`)
+  Grok: `grok` (`v4.1`, `v4.2`, `v4.3`, `latest`, `all`)
 
 - **Z.ai** — `@hebo-ai/gateway/models/zai`  
   GLM: `glm` (`v5`, `v5.1`, `v5.x`, `latest`, `all`)

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -103,6 +103,7 @@ export const CANONICAL_MODEL_IDS = [
   "xai/grok-4.2",
   "xai/grok-4.2-reasoning",
   "xai/grok-4.2-multi-agent",
+  "xai/grok-4.3",
   // DeepSeek
   "deepseek/deepseek-v3.2",
   // Voyage

--- a/src/models/xai/middleware.test.ts
+++ b/src/models/xai/middleware.test.ts
@@ -11,6 +11,7 @@ test("xai middleware > matching patterns", () => {
     "xai/grok-4.1-fast-reasoning",
     "xai/grok-4.2-reasoning",
     "xai/grok-4.2-multi-agent",
+    "xai/grok-4.3",
   ] satisfies (typeof CANONICAL_MODEL_IDS)[number][];
 
   const languageNonMatching = [

--- a/src/models/xai/middleware.ts
+++ b/src/models/xai/middleware.ts
@@ -43,6 +43,11 @@ export const xaiReasoningMiddleware: LanguageModelMiddleware = {
 };
 
 modelMiddlewareMatcher.useForModel(
-  ["xai/grok-4.1-fast-reasoning", "xai/grok-4.2-reasoning", "xai/grok-4.2-multi-agent"],
+  [
+    "xai/grok-4.1-fast-reasoning",
+    "xai/grok-4.2-reasoning",
+    "xai/grok-4.2-multi-agent",
+    "xai/grok-4.3",
+  ],
   { language: [xaiReasoningMiddleware] },
 );

--- a/src/models/xai/presets.ts
+++ b/src/models/xai/presets.ts
@@ -64,9 +64,17 @@ export const grok42MultiAgent = presetFor<CanonicalModelId, CatalogModel>()(
   } satisfies CatalogModel,
 );
 
+export const grok43 = presetFor<CanonicalModelId, CatalogModel>()("xai/grok-4.3" as const, {
+  ...GROK_REASONING_BASE,
+  name: "Grok 4.3",
+  created: "2026-05-01",
+  context: 1000000,
+} satisfies CatalogModel);
+
 const grokAtomic = {
   "v4.1": [grok41Fast, grok41FastReasoning],
   "v4.2": [grok42, grok42Reasoning, grok42MultiAgent],
+  "v4.3": [grok43],
 } as const;
 
 const grokGroups = {} as const;
@@ -74,6 +82,6 @@ const grokGroups = {} as const;
 export const grok = {
   ...grokAtomic,
   ...grokGroups,
-  latest: [grok42, grok42Reasoning, grok42MultiAgent],
+  latest: [grok43],
   all: Object.values(grokAtomic).flat(),
 } as const;

--- a/src/models/xai/presets.ts
+++ b/src/models/xai/presets.ts
@@ -68,6 +68,7 @@ export const grok43 = presetFor<CanonicalModelId, CatalogModel>()("xai/grok-4.3"
   ...GROK_REASONING_BASE,
   name: "Grok 4.3",
   created: "2026-05-01",
+  knowledge: "2024-11",
   context: 1000000,
 } satisfies CatalogModel);
 

--- a/src/providers/xai/canonical.test.ts
+++ b/src/providers/xai/canonical.test.ts
@@ -39,6 +39,13 @@ test("withCanonicalIdsForXai > maps grok-4.2-multi-agent via explicit mapping", 
   expect(model.modelId).toBe("grok-4.20-multi-agent-0309");
 });
 
+test("withCanonicalIdsForXai > maps grok-4.3 via explicit mapping", () => {
+  const provider = withCanonicalIdsForXai(xai);
+
+  const model = provider.languageModel("xai/grok-4.3");
+  expect(model.modelId).toBe("grok-4.3");
+});
+
 test("withCanonicalIdsForXai > supports extra mapping override", () => {
   const provider = withCanonicalIdsForXai(xai, {
     "xai/custom-model": "custom-native-id",

--- a/src/providers/xai/canonical.ts
+++ b/src/providers/xai/canonical.ts
@@ -8,6 +8,7 @@ const MAPPING = {
   "xai/grok-4.2": "grok-4.20-0309-non-reasoning",
   "xai/grok-4.2-reasoning": "grok-4.20-0309-reasoning",
   "xai/grok-4.2-multi-agent": "grok-4.20-multi-agent-0309",
+  "xai/grok-4.3": "grok-4.3",
 } as const satisfies Partial<Record<CanonicalModelId, string>>;
 
 export const withCanonicalIdsForXai = (


### PR DESCRIPTION
## Summary
- Add `xai/grok-4.3` canonical model ID and preset (1M context, reasoning-capable, text+image input)
- Register Grok 4.3 with `xaiReasoningMiddleware` so `reasoning.effort` maps to xAI's `reasoningEffort`
- Add explicit canonical mapping `xai/grok-4.3 → grok-4.3` to preserve the dot in the native xAI model ID

Closes #198

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (629 pass)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for xAI Grok 4.3 with reasoning behavior; the `.latest` preset now defaults to Grok 4.3.

* **Documentation**
  * README updated to list Grok 4.3 as a supported model version.

* **Tests**
  * Added tests validating Grok 4.3 model mapping and matching for reasoning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->