### PR TITLE
feat: export RESPONSE_HEADER_ALLOWLIST from package root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,4 @@ export * from "./models/types";
 export * from "./providers/registry";
 export * from "./providers/types";
 
-export { FORWARD_HEADER_ALLOWLIST } from "./utils";
+export { FORWARD_HEADER_ALLOWLIST, RESPONSE_HEADER_ALLOWLIST } from "./utils";

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -3,7 +3,7 @@ export const RETRY_AFTER_HEADER = "retry-after";
 export const RETRY_AFTER_MS_HEADER = "retry-after-ms";
 export const X_SHOULD_RETRY_HEADER = "x-should-retry";
 
-const RESPONSE_HEADER_ALLOWLIST = [
+export const RESPONSE_HEADER_ALLOWLIST = [
   RETRY_AFTER_HEADER,
   RETRY_AFTER_MS_HEADER,
   X_SHOULD_RETRY_HEADER,


### PR DESCRIPTION
## Summary

- Exports the existing `RESPONSE_HEADER_ALLOWLIST` array from `src/utils/headers.ts` (was private, now `export const`)
- Adds it to the root `src/index.ts` export alongside `FORWARD_HEADER_ALLOWLIST`

This lets hebo-platform import both allowlists to configure the OTEL header recording without duplicating header names. See https://github.com/8monkey-ai/hebo-platform/pull/458.

Closes #200

## Test plan

- [x] No logic change, only visibility (`const` → `export const` + re-export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)