### PR TITLE
fix: accept null optional fields in Responses input items

### DIFF
--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -310,13 +310,13 @@ export function fromChatCompletionsContent(content: ChatCompletionsContentPart[]
   return content.map((part) => {
     switch (part.type) {
       case "image_url":
-        return fromImageUrlPart(part.image_url.url, part.cache_control);
+        return fromImageUrlPart(part.image_url.url, part.cache_control ?? undefined);
       case "file":
         return fromFilePart(
           part.file.data,
           part.file.media_type,
-          part.file.filename,
-          part.cache_control,
+          part.file.filename ?? undefined,
+          part.cache_control ?? undefined,
         );
       case "input_audio":
         return fromFilePart(

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -323,7 +323,7 @@ export function fromChatCompletionsContent(content: ChatCompletionsContentPart[]
           part.input_audio.data,
           `audio/${part.input_audio.format}`,
           undefined,
-          part.cache_control,
+          part.cache_control ?? undefined,
         );
       case "text": {
         const out: TextPart = {

--- a/src/endpoints/chat-completions/schema.test.ts
+++ b/src/endpoints/chat-completions/schema.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+
+import { ChatCompletionsBodySchema } from "./schema";
+
+describe("ChatCompletionsBodySchema", () => {
+  test("accepts assistant message with nullable extension fields (round-trip echo)", () => {
+    const body = {
+      model: "gpt-4o",
+      messages: [
+        { role: "user", content: "hi", name: null, cache_control: null },
+        {
+          role: "assistant",
+          content: "hello",
+          name: null,
+          tool_calls: null,
+          reasoning: null,
+          reasoning_details: null,
+          extra_content: null,
+          cache_control: null,
+        },
+      ],
+    };
+
+    const parsed = ChatCompletionsBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts assistant message with reasoning_details whose fields are all null", () => {
+    const body = {
+      model: "gpt-4o",
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: "",
+          reasoning_details: [
+            {
+              id: null,
+              index: 0,
+              type: "reasoning.text",
+              text: null,
+              signature: null,
+              data: null,
+              summary: null,
+              format: null,
+            },
+          ],
+        },
+      ],
+    };
+
+    const parsed = ChatCompletionsBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts tool_call with null extra_content", () => {
+    const body = {
+      model: "gpt-4o",
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "search", arguments: "{}" },
+              extra_content: null,
+            },
+          ],
+        },
+      ],
+    };
+
+    const parsed = ChatCompletionsBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts user content parts with nullable optional fields", () => {
+    const body = {
+      model: "gpt-4o",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hi", cache_control: null },
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/a.png", detail: null },
+              cache_control: null,
+            },
+            {
+              type: "file",
+              file: {
+                data: "ZmlsZQ==",
+                media_type: "application/pdf",
+                filename: null,
+              },
+              cache_control: null,
+            },
+            {
+              type: "input_audio",
+              input_audio: { data: "YXVkaW8=", format: "mp3" },
+              cache_control: null,
+            },
+          ],
+        },
+      ],
+    };
+
+    const parsed = ChatCompletionsBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts system/user messages with null name and cache_control", () => {
+    const body = {
+      model: "gpt-4o",
+      messages: [
+        { role: "system", content: "sys", name: null, cache_control: null },
+        { role: "user", content: "hi", name: null, cache_control: null },
+      ],
+    };
+
+    const parsed = ChatCompletionsBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/src/endpoints/chat-completions/schema.ts
+++ b/src/endpoints/chat-completions/schema.ts
@@ -36,7 +36,7 @@ export const ChatCompletionsContentPartTextSchema = z.object({
   type: z.literal("text"),
   text: z.string(),
   // Extension origin: Anthropic/OpenRouter/Vercel
-  cache_control: ChatCompletionsCacheControlSchema.optional().meta({ extension: true }),
+  cache_control: ChatCompletionsCacheControlSchema.nullish().meta({ extension: true }),
 });
 export type ChatCompletionsContentPartText = z.infer<typeof ChatCompletionsContentPartTextSchema>;
 
@@ -44,10 +44,10 @@ export const ChatCompletionsContentPartImageSchema = z.object({
   type: z.literal("image_url"),
   image_url: z.object({
     url: z.string(),
-    detail: z.enum(["low", "high", "auto"]).optional(),
+    detail: z.enum(["low", "high", "auto"]).nullish(),
   }),
   // Extension origin: OpenRouter/Vercel/Anthropic
-  cache_control: ChatCompletionsCacheControlSchema.optional().meta({ extension: true }),
+  cache_control: ChatCompletionsCacheControlSchema.nullish().meta({ extension: true }),
 });
 
 export const ChatCompletionsContentPartFileSchema = z.object({
@@ -55,10 +55,10 @@ export const ChatCompletionsContentPartFileSchema = z.object({
   file: z.object({
     data: z.string(),
     media_type: z.string(),
-    filename: z.string().optional(),
+    filename: z.string().nullish(),
   }),
   // Extension origin: OpenRouter/Vercel/Anthropic
-  cache_control: ChatCompletionsCacheControlSchema.optional().meta({ extension: true }),
+  cache_control: ChatCompletionsCacheControlSchema.nullish().meta({ extension: true }),
 });
 
 export const ChatCompletionsContentPartSchema = z.discriminatedUnion("type", [
@@ -77,37 +77,37 @@ export const ChatCompletionsToolCallSchema = z.object({
     name: z.string(),
   }),
   // Extension origin: Gemini
-  extra_content: ChatCompletionsProviderMetadataSchema.optional().meta({ extension: true }),
+  extra_content: ChatCompletionsProviderMetadataSchema.nullish().meta({ extension: true }),
 });
 export type ChatCompletionsToolCall = z.infer<typeof ChatCompletionsToolCallSchema>;
 
 export const ChatCompletionsSystemMessageSchema = z.object({
   role: z.literal("system"),
   content: z.union([z.string(), z.array(ChatCompletionsContentPartTextSchema)]),
-  name: z.string().optional(),
+  name: z.string().nullish(),
   // Extension origin: OpenRouter/Vercel/Anthropic
-  cache_control: ChatCompletionsCacheControlSchema.optional().meta({ extension: true }),
+  cache_control: ChatCompletionsCacheControlSchema.nullish().meta({ extension: true }),
 });
 export type ChatCompletionsSystemMessage = z.infer<typeof ChatCompletionsSystemMessageSchema>;
 
 export const ChatCompletionsUserMessageSchema = z.object({
   role: z.literal("user"),
   content: z.union([z.string(), z.array(ChatCompletionsContentPartSchema)]),
-  name: z.string().optional(),
+  name: z.string().nullish(),
   // Extension origin: OpenRouter/Vercel/Anthropic
-  cache_control: ChatCompletionsCacheControlSchema.optional().meta({ extension: true }),
+  cache_control: ChatCompletionsCacheControlSchema.nullish().meta({ extension: true }),
 });
 export type ChatCompletionsUserMessage = z.infer<typeof ChatCompletionsUserMessageSchema>;
 
 export const ChatCompletionsReasoningDetailSchema = z.object({
-  id: z.string().optional(),
+  id: z.string().nullish(),
   index: z.int().nonnegative(),
   type: z.string(),
-  text: z.string().optional(),
-  signature: z.string().optional(),
-  data: z.string().optional(),
-  summary: z.string().optional(),
-  format: z.string().optional(),
+  text: z.string().nullish(),
+  signature: z.string().nullish(),
+  data: z.string().nullish(),
+  summary: z.string().nullish(),
+  format: z.string().nullish(),
 });
 export type ChatCompletionsReasoningDetail = z.infer<typeof ChatCompletionsReasoningDetailSchema>;
 
@@ -116,20 +116,20 @@ export const ChatCompletionsAssistantMessageSchema = z.object({
   content: z
     .union([z.string(), z.null(), z.array(ChatCompletionsContentPartTextSchema)])
     .optional(),
-  name: z.string().optional(),
+  name: z.string().nullish(),
   // FUTURE: This should also support Custom Tool Calls
-  tool_calls: z.array(ChatCompletionsToolCallSchema).optional(),
+  tool_calls: z.array(ChatCompletionsToolCallSchema).nullish(),
   // Extension origin: OpenRouter/Vercel
-  reasoning: z.string().optional().meta({ extension: true }),
+  reasoning: z.string().nullish().meta({ extension: true }),
   // Extension origin: OpenRouter/Vercel
   reasoning_details: z
     .array(ChatCompletionsReasoningDetailSchema)
-    .optional()
+    .nullish()
     .meta({ extension: true }),
   // Extension origin: Gemini
-  extra_content: ChatCompletionsProviderMetadataSchema.optional().meta({ extension: true }),
+  extra_content: ChatCompletionsProviderMetadataSchema.nullish().meta({ extension: true }),
   // Extension origin: OpenRouter/Vercel/Anthropic
-  cache_control: ChatCompletionsCacheControlSchema.optional().meta({ extension: true }),
+  cache_control: ChatCompletionsCacheControlSchema.nullish().meta({ extension: true }),
 });
 export type ChatCompletionsAssistantMessage = z.infer<typeof ChatCompletionsAssistantMessageSchema>;
 

--- a/src/endpoints/conversations/handler.ts
+++ b/src/endpoints/conversations/handler.ts
@@ -20,7 +20,16 @@ import {
   type ConversationItemList,
   type ConversationList,
 } from "./schema";
-import type { ConversationMetadata } from "./storage/types";
+import type { ConversationItemInput, ConversationMetadata } from "./storage/types";
+import type { ResponsesInputItem } from "../responses/schema";
+
+// Codex-shaped clients echo absent optional fields back as literal null; the
+// request schema accepts that, but the storage layer uses `id?: string`, so
+// normalize null → undefined at the boundary.
+const toStorageItem = (item: ResponsesInputItem): ConversationItemInput => ({
+  ...item,
+  id: item.id ?? undefined,
+});
 
 export const conversations = (config: GatewayConfig): Endpoint => {
   const parsedConfig = parseConfig(config);
@@ -83,7 +92,7 @@ export const conversations = (config: GatewayConfig): Endpoint => {
 
     const entity = await storage.createConversation({
       metadata: parsed.data.metadata as ConversationMetadata,
-      items: parsed.data.items,
+      items: parsed.data.items?.map(toStorageItem),
     });
 
     logger.debug(`[conversations] created conversation: ${entity.id}`);
@@ -220,7 +229,7 @@ export const conversations = (config: GatewayConfig): Endpoint => {
     }
     addSpanEvent("hebo.request.parsed");
 
-    const entities = await storage.addItems(conversationId, parsed.data.items);
+    const entities = await storage.addItems(conversationId, parsed.data.items.map(toStorageItem));
 
     if (!entities) {
       throw new GatewayError("Conversation not found", 404);

--- a/src/endpoints/conversations/storage/types.ts
+++ b/src/endpoints/conversations/storage/types.ts
@@ -7,7 +7,7 @@ export interface ConversationEntity {
 }
 
 export interface ConversationItemInput {
-  id?: string;
+  id?: string | null;
   type: string;
   [key: string]: unknown;
 }

--- a/src/endpoints/conversations/storage/types.ts
+++ b/src/endpoints/conversations/storage/types.ts
@@ -7,7 +7,7 @@ export interface ConversationEntity {
 }
 
 export interface ConversationItemInput {
-  id?: string | null;
+  id?: string;
   type: string;
   [key: string]: unknown;
 }

--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -162,7 +162,7 @@ export function convertThinkingToReasoning(
 
 export function convertToModelMessages(
   messages: MessagesMessage[],
-  system?: string | Array<{ type: "text"; text: string; cache_control?: CacheControl }>,
+  system?: string | Array<{ type: "text"; text: string; cache_control?: CacheControl | null }>,
 ): ModelMessage[] {
   const modelMessages: ModelMessage[] = [];
 
@@ -316,7 +316,7 @@ function fromToolResultBlock(
 ): ToolResultPart {
   let output: ToolResultPart["output"];
 
-  if (block.content === undefined) {
+  if (block.content === undefined || block.content === null) {
     output = { type: "text", value: "" };
   } else if (typeof block.content === "string") {
     output = parseJsonOrText(block.content);

--- a/src/endpoints/messages/schema.test.ts
+++ b/src/endpoints/messages/schema.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+
+import { MessagesBodySchema } from "./schema";
+
+describe("MessagesBodySchema", () => {
+  test("accepts text/image blocks with null cache_control", () => {
+    const body = {
+      model: "claude-sonnet-4",
+      max_tokens: 1024,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hi", cache_control: null },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "aW1n",
+              },
+              cache_control: null,
+            },
+          ],
+        },
+      ],
+    };
+
+    const parsed = MessagesBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts document block with null title/context/cache_control", () => {
+    const body = {
+      model: "claude-sonnet-4",
+      max_tokens: 1024,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "document",
+              source: { type: "url", url: "https://example.com/a.pdf" },
+              title: null,
+              context: null,
+              cache_control: null,
+            },
+          ],
+        },
+      ],
+    };
+
+    const parsed = MessagesBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts tool_use assistant block with null caller/extra_content", () => {
+    const body = {
+      model: "claude-sonnet-4",
+      max_tokens: 1024,
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_1",
+              name: "search",
+              input: {},
+              caller: null,
+              extra_content: null,
+            },
+          ],
+        },
+      ],
+    };
+
+    const parsed = MessagesBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts tool_result block with null content/is_error/cache_control", () => {
+    const body = {
+      model: "claude-sonnet-4",
+      max_tokens: 1024,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_1",
+              content: null,
+              is_error: null,
+              cache_control: null,
+            },
+          ],
+        },
+      ],
+    };
+
+    const parsed = MessagesBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts system block array with null cache_control", () => {
+    const body = {
+      model: "claude-sonnet-4",
+      max_tokens: 1024,
+      system: [{ type: "text", text: "you are helpful", cache_control: null }],
+      messages: [{ role: "user", content: "hi" }],
+    };
+
+    const parsed = MessagesBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/src/endpoints/messages/schema.ts
+++ b/src/endpoints/messages/schema.ts
@@ -9,7 +9,7 @@ import type { ProviderMetadata } from "../shared/schema";
 const TextBlockSchema = z.object({
   type: z.literal("text"),
   text: z.string(),
-  cache_control: CacheControlSchema.optional(),
+  cache_control: CacheControlSchema.nullish(),
 });
 
 const ImageSourceBase64Schema = z.object({
@@ -26,7 +26,7 @@ const ImageSourceUrlSchema = z.object({
 const ImageBlockSchema = z.object({
   type: z.literal("image"),
   source: z.discriminatedUnion("type", [ImageSourceBase64Schema, ImageSourceUrlSchema]),
-  cache_control: CacheControlSchema.optional(),
+  cache_control: CacheControlSchema.nullish(),
 });
 
 const DocumentSourceBase64Schema = z.object({
@@ -54,9 +54,9 @@ const DocumentBlockSchema = z.object({
     DocumentSourceTextSchema,
   ]),
   // FUTURE: pass title/context through to provider (no AI SDK FilePart equivalent yet)
-  title: z.string().optional(),
-  context: z.string().optional(),
-  cache_control: CacheControlSchema.optional(),
+  title: z.string().nullish(),
+  context: z.string().nullish(),
+  cache_control: CacheControlSchema.nullish(),
 });
 
 const ToolUseBlockSchema = z.object({
@@ -65,9 +65,9 @@ const ToolUseBlockSchema = z.object({
   name: z.string(),
   input: z.any(),
   // FUTURE: pass caller through to provider (no AI SDK equivalent yet)
-  caller: z.string().optional(),
+  caller: z.string().nullish(),
   // Extension origin: Gemini — carries thought_signature and other provider metadata for multi-turn
-  extra_content: ProviderMetadataSchema.optional().meta({ extension: true }),
+  extra_content: ProviderMetadataSchema.nullish().meta({ extension: true }),
 });
 
 const ToolResultContentBlockSchema = z.union([
@@ -78,9 +78,9 @@ const ToolResultContentBlockSchema = z.union([
 const ToolResultBlockSchema = z.object({
   type: z.literal("tool_result"),
   tool_use_id: z.string(),
-  content: ToolResultContentBlockSchema.optional(),
-  is_error: z.boolean().optional(),
-  cache_control: CacheControlSchema.optional(),
+  content: ToolResultContentBlockSchema.nullish(),
+  is_error: z.boolean().nullish(),
+  cache_control: CacheControlSchema.nullish(),
 });
 
 const ThinkingBlockSchema = z.object({
@@ -134,7 +134,7 @@ export type MessagesMessage = z.infer<typeof MessagesMessageSchema>;
 const SystemBlockSchema = z.object({
   type: z.literal("text"),
   text: z.string(),
-  cache_control: CacheControlSchema.optional(),
+  cache_control: CacheControlSchema.nullish(),
 });
 
 // --- Tool Schemas ---

--- a/src/endpoints/responses/converters.ts
+++ b/src/endpoints/responses/converters.ts
@@ -314,28 +314,28 @@ function fromInputContent(content: string | ResponsesInputContent[]): UserConten
         result.push({ type: "text", text: part.text });
         break;
       case "input_image": {
-        if (part.image_url !== undefined) {
+        if (part.image_url !== undefined && part.image_url !== null) {
           result.push(fromImageInput(part.image_url));
-        } else if (part.file_id !== undefined) {
+        } else if (part.file_id !== undefined && part.file_id !== null) {
           result.push({ type: "image", image: part.file_id });
         }
         break;
       }
       case "input_file": {
-        if (part.file_data !== undefined) {
-          result.push(fromFileInput(part.file_data, part.filename));
-        } else if (part.file_url !== undefined) {
+        if (part.file_data !== undefined && part.file_data !== null) {
+          result.push(fromFileInput(part.file_data, part.filename ?? undefined));
+        } else if (part.file_url !== undefined && part.file_url !== null) {
           result.push({
             type: "file",
             data: parseUrl(part.file_url),
-            filename: part.filename,
+            filename: part.filename ?? undefined,
             mediaType: "application/octet-stream",
           });
-        } else if (part.file_id !== undefined) {
+        } else if (part.file_id !== undefined && part.file_id !== null) {
           result.push({
             type: "file",
             data: part.file_id,
-            filename: part.filename,
+            filename: part.filename ?? undefined,
             mediaType: "application/octet-stream",
           });
         }
@@ -429,7 +429,7 @@ function fromToolOutput(output: string | ResponsesInputContent[]): ToolResultPar
     }
 
     if (part.type === "input_image") {
-      if (part.image_url !== undefined) {
+      if (part.image_url !== undefined && part.image_url !== null) {
         const { image, mediaType } = parseImageInput(part.image_url);
         if (image instanceof URL) {
           value.push({ type: "image-url", url: image.toString() });
@@ -440,23 +440,23 @@ function fromToolOutput(output: string | ResponsesInputContent[]): ToolResultPar
             mediaType: mediaType!,
           });
         }
-      } else if (part.file_id !== undefined) {
+      } else if (part.file_id !== undefined && part.file_id !== null) {
         value.push({ type: "image-file-id", fileId: part.file_id });
       }
       continue;
     }
 
     if (part.type === "input_file") {
-      if (part.file_data !== undefined) {
+      if (part.file_data !== undefined && part.file_data !== null) {
         value.push({
           type: "file-data",
           data: part.file_data,
           mediaType: "application/octet-stream",
-          filename: part.filename,
+          filename: part.filename ?? undefined,
         });
-      } else if (part.file_url !== undefined) {
+      } else if (part.file_url !== undefined && part.file_url !== null) {
         value.push({ type: "file-url", url: part.file_url });
-      } else if (part.file_id !== undefined) {
+      } else if (part.file_id !== undefined && part.file_id !== null) {
         value.push({ type: "file-id", fileId: part.file_id });
       }
       continue;

--- a/src/endpoints/responses/otel.ts
+++ b/src/endpoints/responses/otel.ts
@@ -255,7 +255,7 @@ export const getResponsesResponseAttributes = (
       "gen_ai.output.messages": responses.output?.map((item) => {
         const base: TelemetryMessageLog = {
           type: item.type,
-          status: item.status,
+          status: item.status ?? undefined,
           parts: [],
         };
 

--- a/src/endpoints/responses/otel.ts
+++ b/src/endpoints/responses/otel.ts
@@ -255,6 +255,7 @@ export const getResponsesResponseAttributes = (
       "gen_ai.output.messages": responses.output?.map((item) => {
         const base: TelemetryMessageLog = {
           type: item.type,
+          // status is `| null` only because the shared schema is reused for input echo; output items always set it.
           status: item.status ?? undefined,
           parts: [],
         };

--- a/src/endpoints/responses/schema.test.ts
+++ b/src/endpoints/responses/schema.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { ResponsesBodySchema } from "./schema";
+
+describe("ResponsesBodySchema", () => {
+  test("accepts reasoning items with nullable fields (Codex follow-up payload)", () => {
+    const body = {
+      model: "sonnet-lak/main/default",
+      instructions: "You are a coding agent.",
+      input: [
+        { type: "message", role: "user", content: "first message" },
+        {
+          type: "reasoning",
+          id: "rs_123",
+          summary: [{ type: "summary_text", text: "thinking..." }],
+          content: null,
+          encrypted_content: null,
+          status: null,
+        },
+        {
+          type: "message",
+          role: "assistant",
+          id: "msg_123",
+          status: null,
+          content: [
+            {
+              type: "output_text",
+              text: "first reply",
+              annotations: null,
+            },
+          ],
+        },
+        { type: "message", role: "user", content: "follow-up message" },
+      ],
+    };
+
+    const parsed = ResponsesBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/src/endpoints/responses/schema.test.ts
+++ b/src/endpoints/responses/schema.test.ts
@@ -37,4 +37,101 @@ describe("ResponsesBodySchema", () => {
     const parsed = ResponsesBodySchema.safeParse(body);
     expect(parsed.success).toBe(true);
   });
+
+  test("accepts function call items with nullable optional fields", () => {
+    const body = {
+      model: "sonnet-lak/main/default",
+      input: [
+        {
+          type: "function_call",
+          id: null,
+          call_id: "call_123",
+          name: "search_docs",
+          arguments: "{}",
+          status: null,
+          extra_content: null,
+          cache_control: null,
+        },
+        {
+          type: "function_call_output",
+          id: null,
+          call_id: "call_123",
+          output: "ok",
+          status: null,
+          extra_content: null,
+          cache_control: null,
+        },
+      ],
+    };
+
+    const parsed = ResponsesBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts input_image content parts with nullable sibling fields", () => {
+    const body = {
+      model: "sonnet-lak/main/default",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_image",
+              image_url: "https://example.com/cat.png",
+              file_id: null,
+              detail: null,
+            },
+            {
+              type: "input_image",
+              file_id: "file_abc",
+              image_url: null,
+              detail: null,
+            },
+          ],
+        },
+      ],
+    };
+
+    const parsed = ResponsesBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts input_file content parts with nullable sibling fields", () => {
+    const body = {
+      model: "sonnet-lak/main/default",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_file",
+              file_data: "base64data",
+              file_id: null,
+              file_url: null,
+              filename: null,
+            },
+            {
+              type: "input_file",
+              file_id: "file_abc",
+              file_data: null,
+              file_url: null,
+              filename: null,
+            },
+            {
+              type: "input_file",
+              file_url: "https://example.com/doc.pdf",
+              file_data: null,
+              file_id: null,
+              filename: null,
+            },
+          ],
+        },
+      ],
+    };
+
+    const parsed = ResponsesBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+  });
 });

--- a/src/endpoints/responses/schema.ts
+++ b/src/endpoints/responses/schema.ts
@@ -29,15 +29,15 @@ export type ResponsesInputText = z.infer<typeof ResponsesInputTextSchema>;
 const ResponsesInputImageURLSchema = z.object({
   type: z.literal("input_image"),
   image_url: z.string(),
-  file_id: z.string().optional(),
-  detail: ResponsesImageDetailSchema.optional(),
+  file_id: z.string().nullish(),
+  detail: ResponsesImageDetailSchema.nullish(),
 });
 
 const ResponsesInputImageIDSchema = z.object({
   type: z.literal("input_image"),
   file_id: z.string(),
-  image_url: z.string().optional(),
-  detail: ResponsesImageDetailSchema.optional(),
+  image_url: z.string().nullish(),
+  detail: ResponsesImageDetailSchema.nullish(),
 });
 
 export const ResponsesInputImageSchema = z.union([
@@ -49,25 +49,25 @@ export type ResponsesInputImage = z.infer<typeof ResponsesInputImageSchema>;
 const ResponsesInputFileDataSchema = z.object({
   type: z.literal("input_file"),
   file_data: z.string(),
-  file_id: z.string().optional(),
-  file_url: z.string().optional(),
-  filename: z.string().optional(),
+  file_id: z.string().nullish(),
+  file_url: z.string().nullish(),
+  filename: z.string().nullish(),
 });
 
 const ResponsesInputFileIDSchema = z.object({
   type: z.literal("input_file"),
   file_id: z.string(),
-  file_data: z.string().optional(),
-  file_url: z.string().optional(),
-  filename: z.string().optional(),
+  file_data: z.string().nullish(),
+  file_url: z.string().nullish(),
+  filename: z.string().nullish(),
 });
 
 const ResponsesInputFileURLSchema = z.object({
   type: z.literal("input_file"),
   file_url: z.string(),
-  file_data: z.string().optional(),
-  file_id: z.string().optional(),
-  filename: z.string().optional(),
+  file_data: z.string().nullish(),
+  file_id: z.string().nullish(),
+  filename: z.string().nullish(),
 });
 
 export const ResponsesInputFileSchema = z.union([

--- a/src/endpoints/responses/schema.ts
+++ b/src/endpoints/responses/schema.ts
@@ -91,7 +91,7 @@ export type ResponsesInputContent = z.infer<typeof ResponsesInputContentSchema>;
 export const ResponsesOutputTextSchema = z.object({
   type: z.literal("output_text"),
   text: z.string(),
-  annotations: z.array(z.unknown()).optional(),
+  annotations: z.array(z.unknown()).nullish(),
 });
 export type ResponsesOutputText = z.infer<typeof ResponsesOutputTextSchema>;
 
@@ -99,12 +99,12 @@ export type ResponsesOutputText = z.infer<typeof ResponsesOutputTextSchema>;
 
 const ResponsesMessageItemBaseSchema = z.object({
   type: z.literal("message"),
-  id: z.string().optional(),
-  status: ResponsesItemStatusSchema.optional(),
+  id: z.string().nullish(),
+  status: ResponsesItemStatusSchema.nullish(),
   // Extension origin: Gemini
-  extra_content: ResponsesProviderMetadataSchema.optional().meta({ extension: true }),
+  extra_content: ResponsesProviderMetadataSchema.nullish().meta({ extension: true }),
   // Extension origin: Anthropic/OpenRouter/Vercel
-  cache_control: ResponsesCacheControlSchema.optional().meta({ extension: true }),
+  cache_control: ResponsesCacheControlSchema.nullish().meta({ extension: true }),
 });
 
 const ResponsesUserMessageSchema = ResponsesMessageItemBaseSchema.extend({
@@ -141,28 +141,28 @@ export type ResponsesMessageItem = z.infer<typeof ResponsesMessageItemSchema>;
 
 export const ResponsesFunctionCallSchema = z.object({
   type: z.literal("function_call"),
-  id: z.string().optional(),
+  id: z.string().nullish(),
   call_id: z.string(),
   name: z.string(),
   arguments: z.string(),
-  status: ResponsesItemStatusSchema.optional(),
+  status: ResponsesItemStatusSchema.nullish(),
   // Extension origin: Gemini
-  extra_content: ResponsesProviderMetadataSchema.optional().meta({ extension: true }),
+  extra_content: ResponsesProviderMetadataSchema.nullish().meta({ extension: true }),
   // Extension origin: Anthropic/OpenRouter/Vercel
-  cache_control: ResponsesCacheControlSchema.optional().meta({ extension: true }),
+  cache_control: ResponsesCacheControlSchema.nullish().meta({ extension: true }),
 });
 export type ResponsesFunctionCall = z.infer<typeof ResponsesFunctionCallSchema>;
 
 export const ResponsesFunctionCallOutputSchema = z.object({
   type: z.literal("function_call_output"),
-  id: z.string().optional(),
+  id: z.string().nullish(),
   call_id: z.string(),
   output: z.union([z.string(), z.array(ResponsesInputContentSchema)]),
-  status: ResponsesItemStatusSchema.optional(),
+  status: ResponsesItemStatusSchema.nullish(),
   // Extension origin: Gemini
-  extra_content: ResponsesProviderMetadataSchema.optional().meta({ extension: true }),
+  extra_content: ResponsesProviderMetadataSchema.nullish().meta({ extension: true }),
   // Extension origin: Anthropic/OpenRouter/Vercel
-  cache_control: ResponsesCacheControlSchema.optional().meta({ extension: true }),
+  cache_control: ResponsesCacheControlSchema.nullish().meta({ extension: true }),
 });
 export type ResponsesFunctionCallOutput = z.infer<typeof ResponsesFunctionCallOutputSchema>;
 
@@ -184,15 +184,15 @@ export type ResponsesReasoningText = z.infer<typeof ResponsesReasoningTextSchema
 
 export const ResponsesReasoningItemSchema = z.object({
   type: z.literal("reasoning"),
-  id: z.string().optional(),
+  id: z.string().nullish(),
   summary: z.array(ResponsesSummaryTextSchema),
-  content: z.array(ResponsesReasoningTextSchema).optional(),
-  encrypted_content: z.string().optional(),
-  status: ResponsesItemStatusSchema.optional(),
+  content: z.array(ResponsesReasoningTextSchema).nullish(),
+  encrypted_content: z.string().nullish(),
+  status: ResponsesItemStatusSchema.nullish(),
   // Extension origin: Gemini
-  extra_content: ResponsesProviderMetadataSchema.optional().meta({ extension: true }),
+  extra_content: ResponsesProviderMetadataSchema.nullish().meta({ extension: true }),
   // Extension origin: Anthropic/OpenRouter
-  signature: z.string().optional().meta({ extension: true }),
+  signature: z.string().nullish().meta({ extension: true }),
 });
 export type ResponsesReasoningItem = z.infer<typeof ResponsesReasoningItemSchema>;
 

--- a/src/endpoints/shared/schema.ts
+++ b/src/endpoints/shared/schema.ts
@@ -84,6 +84,6 @@ export const ContentPartAudioSchema = z.object({
   type: z.literal("input_audio"),
   input_audio: InputAudioSchema,
   // Extension origin: OpenRouter/Vercel/Anthropic
-  cache_control: CacheControlSchema.optional().meta({ extension: true }),
+  cache_control: CacheControlSchema.nullish().meta({ extension: true }),
 });
 export type ContentPartAudio = z.infer<typeof ContentPartAudioSchema>;


### PR DESCRIPTION
## Summary
- Switch Responses input-item schemas (reasoning, message, function_call, output_text) from .optional() to .nullish() so follow-up requests from Codex parse successfully
- Codex echoes previous-turn items back with literal null for absent fields (encrypted_content, content, annotations, status, id); the old schema rejected them, collapsing the error up to `at input`
- Add regression test that parses a Codex-style follow-up payload

Fixes #203

## Test plan
- [x] bun run check (lint + typecheck)
- [x] bun run test (630 pass)
- [ ] Manual: configure Codex against gateway, send two messages in the same session

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced support for nullable fields in API requests and responses, ensuring proper handling when clients send `null` values instead of omitting the field.
  * Improved compatibility with API clients that represent absent fields as `null` values.

* **Tests**
  * Added comprehensive test coverage validating correct parsing of API payloads containing nullable and optional fields across multiple endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->