### PR TITLE
fix(responses): accept hosted tools like web_search in /v1/responses

### DIFF
--- a/src/endpoints/chat-completions/converters.test.ts
+++ b/src/endpoints/chat-completions/converters.test.ts
@@ -593,6 +593,36 @@ describe("Chat Completions Converters", () => {
       expect(Object.keys(result.tools!)).toEqual(["get_weather"]);
     });
 
+    test("should drop hosted tools when mixed with function tools", () => {
+      const result = convertToTextCallOptions({
+        messages: [{ role: "user", content: "hi" }],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "get_weather",
+              description: "Get weather",
+              parameters: { type: "object", properties: {} },
+            },
+          },
+          { type: "web_search" },
+          { type: "file_search", vector_store_ids: ["vs_123"] },
+        ],
+      });
+
+      expect(result.tools).toBeDefined();
+      expect(Object.keys(result.tools!)).toEqual(["get_weather"]);
+    });
+
+    test("should leave tools undefined when only hosted tools are present", () => {
+      const result = convertToTextCallOptions({
+        messages: [{ role: "user", content: "hi" }],
+        tools: [{ type: "web_search" }, { type: "code_interpreter" }],
+      });
+
+      expect(result.tools).toBeUndefined();
+    });
+
     test("should map prompt cache options into providerOptions.unknown", () => {
       const result = convertToTextCallOptions({
         messages: [{ role: "system", content: "You are concise." }],

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -411,6 +411,7 @@ export const convertToToolSet = (tools: ChatCompletionsTool[] | undefined): Tool
   for (const t of tools) {
     // Hosted/built-in tools (e.g. web_search) are accepted at the edge but
     // not executed by the gateway; drop anything that isn't a function tool.
+    // FUTURE: log dropped hosted tools at debug level (once per request, batched)
     if (t.type !== "function") continue;
     const fn = t as ChatCompletionsFunctionTool;
     toolSet[fn.function.name] = tool({

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -411,7 +411,7 @@ export const convertToToolSet = (tools: ChatCompletionsTool[] | undefined): Tool
   for (const t of tools) {
     // Hosted/built-in tools (e.g. web_search) are accepted at the edge but
     // not executed by the gateway; drop anything that isn't a function tool.
-    // FUTURE: log dropped hosted tools at debug level (once per request, batched)
+    // FUTURE: log dropped hosted tools at warn level (once per request, batched)
     if (t.type !== "function") continue;
     const fn = t as ChatCompletionsFunctionTool;
     toolSet[fn.function.name] = tool({

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -40,6 +40,7 @@ import {
 import type {
   ChatCompletionsToolCall,
   ChatCompletionsTool,
+  ChatCompletionsFunctionTool,
   ChatCompletionsToolChoice,
   ChatCompletionsStream,
   ChatCompletionsContentPart,
@@ -408,13 +409,17 @@ export const convertToToolSet = (tools: ChatCompletionsTool[] | undefined): Tool
 
   const toolSet: ToolSet = {};
   for (const t of tools) {
-    toolSet[t.function.name] = tool({
-      description: t.function.description,
-      inputSchema: jsonSchema(t.function.parameters),
-      strict: t.function.strict,
+    // Hosted/built-in tools (e.g. web_search) are accepted at the edge but
+    // not executed by the gateway; drop anything that isn't a function tool.
+    if (t.type !== "function") continue;
+    const fn = t as ChatCompletionsFunctionTool;
+    toolSet[fn.function.name] = tool({
+      description: fn.function.description,
+      inputSchema: jsonSchema(fn.function.parameters),
+      strict: fn.function.strict,
     });
   }
-  return toolSet;
+  return Object.keys(toolSet).length > 0 ? toolSet : undefined;
 };
 
 export const convertToToolChoiceOptions = (

--- a/src/endpoints/chat-completions/handler.test.ts
+++ b/src/endpoints/chat-completions/handler.test.ts
@@ -293,6 +293,44 @@ describe("Chat Completions Handler", () => {
     } satisfies Partial<ChatCompletions>);
   });
 
+  test("should accept requests with hosted tools (e.g. web_search) alongside function tools", async () => {
+    const request = postJson(baseUrl, {
+      model: "openai/gpt-oss-20b",
+      messages: [{ role: "user", content: "What is the weather in SF?" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "get_current_weather",
+            description: "Get the current weather",
+            parameters: {
+              type: "object",
+              properties: { location: { type: "string" } },
+            },
+          },
+        },
+        { type: "web_search" },
+        { type: "file_search", vector_store_ids: ["vs_123"] },
+      ],
+    });
+
+    const res = await endpoint.handler(request);
+    expect(res.status).toBe(200);
+    const data = await parseResponse<ChatCompletions>(res);
+    expect(data!.choices[0]!.finish_reason).toBe("tool_calls");
+  });
+
+  test("should accept requests with only hosted tools", async () => {
+    const request = postJson(baseUrl, {
+      model: "openai/gpt-oss-20b",
+      messages: [{ role: "user", content: "Search for recent news" }],
+      tools: [{ type: "web_search" }],
+    });
+
+    const res = await endpoint.handler(request);
+    expect(res.status).toBe(200);
+  });
+
   test("should generate streaming completion successfully", async () => {
     const request = postJson(baseUrl, {
       model: "openai/gpt-oss-20b",

--- a/src/endpoints/chat-completions/schema.ts
+++ b/src/endpoints/chat-completions/schema.ts
@@ -148,7 +148,7 @@ export const ChatCompletionsMessageSchema = z.discriminatedUnion("role", [
 ]);
 export type ChatCompletionsMessage = z.infer<typeof ChatCompletionsMessageSchema>;
 
-export const ChatCompletionsToolSchema = z.object({
+export const ChatCompletionsFunctionToolSchema = z.object({
   type: z.literal("function"),
   function: z.object({
     name: z.string(),
@@ -158,6 +158,25 @@ export const ChatCompletionsToolSchema = z.object({
   }),
   // FUTURE: cache_control support on tools
 });
+export type ChatCompletionsFunctionTool = z.infer<typeof ChatCompletionsFunctionToolSchema>;
+
+// Hosted/built-in tools (e.g. web_search, file_search, code_interpreter).
+// Accepted at the edge so clients like Codex can send their default payload,
+// but not executed by the gateway — they are dropped before the AI SDK call
+// unless the downstream handler explicitly opts them in.
+export const ChatCompletionsHostedToolSchema = z
+  .looseObject({
+    type: z.string(),
+  })
+  .refine((value) => value.type !== "function", {
+    message: 'Function tools must use the function tool schema (type: "function")',
+  });
+export type ChatCompletionsHostedTool = z.infer<typeof ChatCompletionsHostedToolSchema>;
+
+export const ChatCompletionsToolSchema = z.union([
+  ChatCompletionsFunctionToolSchema,
+  ChatCompletionsHostedToolSchema,
+]);
 export type ChatCompletionsTool = z.infer<typeof ChatCompletionsToolSchema>;
 
 const ChatCompletionsNamedFunctionToolChoiceSchema = z.object({

--- a/src/endpoints/messages/converters.test.ts
+++ b/src/endpoints/messages/converters.test.ts
@@ -576,6 +576,14 @@ describe("Messages Converters", () => {
       ]);
       expect(toolSet).toBeUndefined();
     });
+
+    test("should drop tools with empty-string type", () => {
+      // Empty string passes z.string() in the hosted schema and survives the
+      // refine (it's not "custom"), so validation accepts the tool. The
+      // converter must still drop it rather than mistake it for a custom tool.
+      const toolSet = convertToToolSet([{ type: "", name: "bogus" }]);
+      expect(toolSet).toBeUndefined();
+    });
   });
 
   describe("convertToToolChoiceOptions", () => {

--- a/src/endpoints/messages/converters.test.ts
+++ b/src/endpoints/messages/converters.test.ts
@@ -554,6 +554,28 @@ describe("Messages Converters", () => {
       expect(toolSet).toBeDefined();
       expect(Object.keys(toolSet!)).toEqual(["strict_tool"]);
     });
+
+    test("should drop hosted server tools when mixed with custom tools", () => {
+      const toolSet = convertToToolSet([
+        {
+          name: "get_weather",
+          description: "Get weather",
+          input_schema: { type: "object", properties: {} },
+        },
+        { type: "web_search_20250305", name: "web_search", max_uses: 5 },
+        { type: "computer_20250124", name: "computer" },
+      ]);
+      expect(toolSet).toBeDefined();
+      expect(Object.keys(toolSet!)).toEqual(["get_weather"]);
+    });
+
+    test("should return undefined when only hosted tools are present", () => {
+      const toolSet = convertToToolSet([
+        { type: "web_search_20250305", name: "web_search" },
+        { type: "bash_20250124", name: "bash" },
+      ]);
+      expect(toolSet).toBeUndefined();
+    });
   });
 
   describe("convertToToolChoiceOptions", () => {

--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -416,7 +416,7 @@ export function convertToToolSet(tools: MessagesTool[] | undefined): ToolSet | u
   for (const t of tools) {
     // Hosted/server tools (e.g. web_search_20250305) are accepted at the edge
     // but not executed by the gateway; drop anything with a non-"custom" type.
-    if (t.type && t.type !== "custom") continue;
+    if (t.type !== undefined && t.type !== "custom") continue;
     const fn = t as MessagesCustomTool;
     toolSet[fn.name] = tool({
       description: fn.description,

--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -416,7 +416,7 @@ export function convertToToolSet(tools: MessagesTool[] | undefined): ToolSet | u
   for (const t of tools) {
     // Hosted/server tools (e.g. web_search_20250305) are accepted at the edge
     // but not executed by the gateway; drop anything with a non-"custom" type.
-    // FUTURE: log dropped hosted tools at debug level (once per request, batched)
+    // FUTURE: log dropped hosted tools at warn level (once per request, batched)
     if (t.type !== undefined && t.type !== "custom") continue;
     const fn = t as MessagesCustomTool;
     toolSet[fn.name] = tool({

--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -36,6 +36,7 @@ import type {
   MessagesMessage,
   UserContentBlock,
   MessagesTool,
+  MessagesCustomTool,
   MessagesToolChoice,
   MessagesThinkingConfig,
   MessagesOutputConfig,
@@ -413,13 +414,17 @@ export function convertToToolSet(tools: MessagesTool[] | undefined): ToolSet | u
 
   const toolSet: ToolSet = {};
   for (const t of tools) {
-    toolSet[t.name] = tool({
-      description: t.description,
-      inputSchema: jsonSchema(t.input_schema),
-      strict: t.strict,
+    // Hosted/server tools (e.g. web_search_20250305) are accepted at the edge
+    // but not executed by the gateway; drop anything with a non-"custom" type.
+    if (t.type && t.type !== "custom") continue;
+    const fn = t as MessagesCustomTool;
+    toolSet[fn.name] = tool({
+      description: fn.description,
+      inputSchema: jsonSchema(fn.input_schema),
+      strict: fn.strict,
     });
   }
-  return toolSet;
+  return Object.keys(toolSet).length > 0 ? toolSet : undefined;
 }
 
 export function convertToToolChoiceOptions(

--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -416,6 +416,7 @@ export function convertToToolSet(tools: MessagesTool[] | undefined): ToolSet | u
   for (const t of tools) {
     // Hosted/server tools (e.g. web_search_20250305) are accepted at the edge
     // but not executed by the gateway; drop anything with a non-"custom" type.
+    // FUTURE: log dropped hosted tools at debug level (once per request, batched)
     if (t.type !== undefined && t.type !== "custom") continue;
     const fn = t as MessagesCustomTool;
     toolSet[fn.name] = tool({

--- a/src/endpoints/messages/handler.test.ts
+++ b/src/endpoints/messages/handler.test.ts
@@ -237,6 +237,40 @@ describe("Messages Handler", () => {
     expect((toolUse as { name: string }).name).toBe("get_current_weather");
   });
 
+  test("should accept requests with hosted server tools alongside custom tools", async () => {
+    const request = postJson(baseUrl, {
+      model: "openai/gpt-oss-20b",
+      max_tokens: 100,
+      messages: [{ role: "user", content: "What is the weather in SF?" }],
+      tools: [
+        {
+          name: "get_current_weather",
+          description: "Get the current weather",
+          input_schema: {
+            type: "object",
+            properties: { location: { type: "string" } },
+          },
+        },
+        { type: "web_search_20250305", name: "web_search", max_uses: 5 },
+      ],
+    });
+    const res = await endpoint.handler(request);
+    expect(res.status).toBe(200);
+    const data = await parseResponse<Messages>(res);
+    expect(data!.stop_reason).toBe("tool_use");
+  });
+
+  test("should accept requests with only hosted server tools", async () => {
+    const request = postJson(baseUrl, {
+      model: "openai/gpt-oss-20b",
+      max_tokens: 100,
+      messages: [{ role: "user", content: "Search recent news" }],
+      tools: [{ type: "web_search_20250305", name: "web_search" }],
+    });
+    const res = await endpoint.handler(request);
+    expect(res.status).toBe(200);
+  });
+
   test("should accept tool_choice auto", async () => {
     const request = postJson(baseUrl, {
       model: "openai/gpt-oss-20b",

--- a/src/endpoints/messages/schema.ts
+++ b/src/endpoints/messages/schema.ts
@@ -139,13 +139,30 @@ const SystemBlockSchema = z.object({
 
 // --- Tool Schemas ---
 
-const MessagesToolSchema = z.object({
+const MessagesCustomToolSchema = z.object({
+  type: z.literal("custom").optional(),
   name: z.string(),
   description: z.string().optional(),
   input_schema: z.any(),
   // FUTURE: cache_control support on tools
   strict: z.boolean().optional(),
 });
+export type MessagesCustomTool = z.infer<typeof MessagesCustomToolSchema>;
+
+// Hosted/server tools (e.g. web_search_20250305, computer_20250124).
+// Accepted at the edge so clients can send their default payload, but not
+// executed by the gateway — they are dropped before the AI SDK call unless the
+// downstream handler explicitly opts them in.
+const MessagesHostedToolSchema = z
+  .looseObject({
+    type: z.string(),
+  })
+  .refine((value) => value.type !== "custom", {
+    message: 'Custom tools must use the custom tool schema (omit "type" or use type: "custom")',
+  });
+export type MessagesHostedTool = z.infer<typeof MessagesHostedToolSchema>;
+
+const MessagesToolSchema = z.union([MessagesCustomToolSchema, MessagesHostedToolSchema]);
 export type MessagesTool = z.infer<typeof MessagesToolSchema>;
 
 const MessagesToolChoiceAutoSchema = z.object({

--- a/src/endpoints/responses/converters.test.ts
+++ b/src/endpoints/responses/converters.test.ts
@@ -469,6 +469,34 @@ describe("Responses Converters", () => {
       expect(Object.keys(result.tools!)).toEqual(["get_weather"]);
     });
 
+    test("should drop hosted tools when mixed with function tools", () => {
+      const result = convertToTextCallOptions({
+        input: "hi",
+        tools: [
+          {
+            type: "function",
+            name: "get_weather",
+            description: "Get weather",
+            parameters: { type: "object", properties: {} },
+          },
+          { type: "web_search" },
+          { type: "file_search", vector_store_ids: ["vs_123"] },
+        ],
+      });
+
+      expect(result.tools).toBeDefined();
+      expect(Object.keys(result.tools!)).toEqual(["get_weather"]);
+    });
+
+    test("should leave tools undefined when only hosted tools are present", () => {
+      const result = convertToTextCallOptions({
+        input: "hi",
+        tools: [{ type: "web_search" }, { type: "code_interpreter" }],
+      });
+
+      expect(result.tools).toBeUndefined();
+    });
+
     test("should convert tool_choice auto/required/none", () => {
       expect(convertToTextCallOptions({ input: "hi", tool_choice: "auto" }).toolChoice).toBe(
         "auto",

--- a/src/endpoints/responses/converters.ts
+++ b/src/endpoints/responses/converters.ts
@@ -57,6 +57,7 @@ import type {
   ResponsesStreamEvent,
   ResponsesToolChoice,
   ResponsesTool,
+  ResponsesFunctionTool,
   ResponsesTextConfig,
   ResponsesSummaryText,
   ResponsesReasoningText,
@@ -505,13 +506,17 @@ export const convertToToolSet = (tools: ResponsesTool[] | undefined): ToolSet | 
 
   const toolSet: ToolSet = {};
   for (const t of tools) {
-    toolSet[t.name] = tool({
-      description: t.description,
-      inputSchema: jsonSchema(t.parameters),
-      strict: t.strict,
+    // Hosted/built-in tools (e.g. web_search) are accepted at the edge but
+    // not executed by the gateway; drop anything that isn't a function tool.
+    if (t.type !== "function") continue;
+    const fn = t as ResponsesFunctionTool;
+    toolSet[fn.name] = tool({
+      description: fn.description,
+      inputSchema: jsonSchema(fn.parameters),
+      strict: fn.strict,
     });
   }
-  return toolSet;
+  return Object.keys(toolSet).length > 0 ? toolSet : undefined;
 };
 
 export const convertToToolChoiceOptions = (

--- a/src/endpoints/responses/converters.ts
+++ b/src/endpoints/responses/converters.ts
@@ -508,7 +508,7 @@ export const convertToToolSet = (tools: ResponsesTool[] | undefined): ToolSet | 
   for (const t of tools) {
     // Hosted/built-in tools (e.g. web_search) are accepted at the edge but
     // not executed by the gateway; drop anything that isn't a function tool.
-    // FUTURE: log dropped hosted tools at debug level (once per request, batched)
+    // FUTURE: log dropped hosted tools at warn level (once per request, batched)
     if (t.type !== "function") continue;
     const fn = t as ResponsesFunctionTool;
     toolSet[fn.name] = tool({

--- a/src/endpoints/responses/converters.ts
+++ b/src/endpoints/responses/converters.ts
@@ -508,6 +508,7 @@ export const convertToToolSet = (tools: ResponsesTool[] | undefined): ToolSet | 
   for (const t of tools) {
     // Hosted/built-in tools (e.g. web_search) are accepted at the edge but
     // not executed by the gateway; drop anything that isn't a function tool.
+    // FUTURE: log dropped hosted tools at debug level (once per request, batched)
     if (t.type !== "function") continue;
     const fn = t as ResponsesFunctionTool;
     toolSet[fn.name] = tool({

--- a/src/endpoints/responses/handler.test.ts
+++ b/src/endpoints/responses/handler.test.ts
@@ -261,6 +261,44 @@ describe("Responses Handler", () => {
     expect(fnCall).toBeDefined();
   });
 
+  test("should accept requests with hosted tools (e.g. web_search) alongside function tools", async () => {
+    const request = postJson(baseUrl, {
+      model: "openai/gpt-oss-20b",
+      input: "What is the weather in SF?",
+      tools: [
+        {
+          type: "function",
+          name: "get_current_weather",
+          description: "Get the current weather",
+          parameters: {
+            type: "object",
+            properties: { location: { type: "string" } },
+          },
+        },
+        { type: "web_search" },
+        { type: "file_search", vector_store_ids: ["vs_123"] },
+      ],
+    });
+
+    const res = await endpoint.handler(request);
+    expect(res.status).toBe(200);
+    const data = await parseResponse<Responses>(res);
+    expect(data!.status).toBe("completed");
+  });
+
+  test("should accept requests with only hosted tools", async () => {
+    const request = postJson(baseUrl, {
+      model: "openai/gpt-oss-20b",
+      input: "Search for recent news",
+      tools: [{ type: "web_search" }],
+    });
+
+    const res = await endpoint.handler(request);
+    expect(res.status).toBe(200);
+    const data = await parseResponse<Responses>(res);
+    expect(data!.status).toBe("completed");
+  });
+
   test("should generate streaming response successfully", async () => {
     const request = postJson(baseUrl, {
       model: "openai/gpt-oss-20b",

--- a/src/endpoints/responses/schema.ts
+++ b/src/endpoints/responses/schema.ts
@@ -243,13 +243,32 @@ export {
  * --- Tools ---
  */
 
-export const ResponsesToolSchema = z.object({
+export const ResponsesFunctionToolSchema = z.object({
   type: z.literal("function"),
   name: z.string(),
   description: z.string().optional(),
   parameters: z.record(z.string(), z.unknown()),
   strict: z.boolean().optional(),
 });
+export type ResponsesFunctionTool = z.infer<typeof ResponsesFunctionToolSchema>;
+
+// Hosted/built-in tools (e.g. web_search, file_search, code_interpreter).
+// Accepted at the edge so clients like Codex can send their default payload,
+// but not executed by the gateway — they are dropped before the AI SDK call
+// unless the downstream handler explicitly opts them in.
+export const ResponsesHostedToolSchema = z
+  .looseObject({
+    type: z.string(),
+  })
+  .refine((value) => value.type !== "function", {
+    message: 'Function tools must use the function tool schema (type: "function")',
+  });
+export type ResponsesHostedTool = z.infer<typeof ResponsesHostedToolSchema>;
+
+export const ResponsesToolSchema = z.union([
+  ResponsesFunctionToolSchema,
+  ResponsesHostedToolSchema,
+]);
 export type ResponsesTool = z.infer<typeof ResponsesToolSchema>;
 
 const ResponsesNamedFunctionToolChoiceSchema = z.object({


### PR DESCRIPTION
## Summary

The `/v1/responses` tool schema only accepted `type: "function"` tools, so requests from clients like Codex that include a default `web_search` tool failed with `400 bad_request`.

- Widen the schema to accept arbitrary hosted tool types (no hardcoded allowlist) via a union of `ResponsesFunctionToolSchema` + `ResponsesHostedToolSchema` (`looseObject` refined to reject `type: "function"`).
- In `convertToToolSet`, drop non-function tools before handing off to the AI SDK (which only knows about function tools), and return `undefined` when only hosted tools are present.

Hosted tools are accepted at the edge but not executed by the gateway. Actually executing them (e.g. via `openai.tools.webSearchPreview()) is left as a separate feature.

Fixes #204

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (633 pass)
- [x] New converter tests: mixed function + hosted tools → only function tools reach AI SDK; hosted-only → `tools` is `undefined`
- [x] New handler tests: `200` for mixed and hosted-only payloads

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoints now accept hosted/built‑in tools alongside custom function tools; when mixed, only function tools are kept for invocation, and requests with only hosted tools are accepted but yield no function-tool set.

* **Tests**
  * Added tests verifying mixed and hosted-only tool configurations across chat completions, messages, and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->