### PR TITLE
fix(responses-otel): always emit role on output messages

### DIFF
--- a/src/endpoints/responses/otel.test.ts
+++ b/src/endpoints/responses/otel.test.ts
@@ -246,10 +246,10 @@ describe("Responses OTEL", () => {
 
     expect(attrs["gen_ai.output.messages"]).toEqual([
       JSON.stringify({
+        role: "assistant",
         type: "message",
         status: "completed",
         parts: [{ type: "text", content: "Hi there" }],
-        role: "assistant",
       }),
     ]);
   });
@@ -278,6 +278,7 @@ describe("Responses OTEL", () => {
 
     expect(attrs["gen_ai.output.messages"]).toEqual([
       JSON.stringify({
+        role: "assistant",
         type: "reasoning",
         status: "completed",
         parts: [
@@ -285,6 +286,40 @@ describe("Responses OTEL", () => {
           { type: "reasoning", content: "Cats are feline." },
           { type: "reasoning", content: "[ENCRYPTED_REASONING]" },
         ],
+      }),
+    ]);
+  });
+
+  test("should include role on function_call output items in full mode", () => {
+    const response: Responses = {
+      id: "018e69ba-a82d-7fb4-9c5d-010b9a89c836",
+      object: "response",
+      status: "completed",
+      model: "openai/gpt-5",
+      output: [
+        {
+          type: "function_call",
+          call_id: "call_1",
+          name: "get_weather",
+          arguments: '{"location":"SF"}',
+          status: "completed",
+        },
+      ],
+      usage: null,
+      created_at: 1700000000,
+      completed_at: 1700000001,
+    };
+
+    const attrs = getResponsesResponseAttributes(response, "full");
+
+    expect(attrs["gen_ai.output.messages"]).toEqual([
+      JSON.stringify({
+        role: "assistant",
+        type: "function_call",
+        status: "completed",
+        parts: [],
+        name: "get_weather",
+        arguments: '{"location":"SF"}',
       }),
     ]);
   });

--- a/src/endpoints/responses/otel.ts
+++ b/src/endpoints/responses/otel.ts
@@ -254,6 +254,7 @@ export const getResponsesResponseAttributes = (
     Object.assign(attrs, {
       "gen_ai.output.messages": responses.output?.map((item) => {
         const base: TelemetryMessageLog = {
+          role: "assistant",
           type: item.type,
           status: item.status,
           parts: [],


### PR DESCRIPTION
## Summary

- `/responses` OTEL handler now emits a `role` field on every `gen_ai.output.messages` entry (previously missing for `reasoning` and `function_call` items).
- All output items in a `Responses` come from the assistant, so `role: "assistant"` is the correct default; the existing `message` branch still overrides with `item.role`.
- Matches the shape already produced by `/chat/completions` and `/messages`.

## Test plan

- [x] `bun test src/endpoints/responses/otel.test.ts` — 12/12 pass
- [x] `bun check` (lint + typecheck) clean
- [x] New test case added for `function_call` output items

Closes #209

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced telemetry data structure to ensure consistent role field population for assistant responses and function-call outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->