### PR TITLE
fix: flush ctx.otel attributes to span in finalize

### DIFF
--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import { context, trace } from "@opentelemetry/api";
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
-import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
 import { MockProviderV3 } from "ai/test";
 
 import { models } from "./endpoints/models/handler";
@@ -130,5 +134,43 @@ describe("winterCgHandler", () => {
     expect(await response.text()).toBe("teapot");
     expect(onErrorTraceId).toBeDefined();
     expect(onResponseCalled).toBe(false);
+  });
+
+  test("flushes ctx.otel attributes to the span when handler throws", async () => {
+    context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+
+    const exporter = new InMemorySpanExporter();
+    const tracerProvider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+
+    const handler = winterCgHandler(
+      async (ctx) => {
+        ctx.operation = "chat";
+        ctx.otel["custom.tenant"] = "tenant-123";
+        throw new Error("provider config missing");
+      },
+      {
+        providers: { openai: new MockProviderV3() },
+        models: {
+          "openai/gpt-oss-20b": {
+            name: "GPT-OSS 20B",
+            modalities: { input: ["text"], output: ["text"] },
+            providers: ["openai"],
+          },
+        },
+        telemetry: { enabled: true, tracer: tracerProvider.getTracer("test") },
+      },
+    );
+
+    const response = await handler(
+      new Request("http://localhost/v1/chat/completions", { method: "POST" }),
+    );
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    expect(spans[0]!.attributes["custom.tenant"]).toBe("tenant-123");
   });
 });

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -61,6 +61,8 @@ export const winterCgHandler = (
         span.updateName(`${ctx.operation}${ctx.modelId ? ` ${ctx.modelId}` : ""}`);
       }
 
+      span.setAttributes(ctx.otel);
+
       if (!span.isExisting) {
         // FUTURE add http.server.request.duration
         span.setAttributes(

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -61,8 +61,6 @@ export const winterCgHandler = (
         span.updateName(`${ctx.operation}${ctx.modelId ? ` ${ctx.modelId}` : ""}`);
       }
 
-      span.setAttributes(ctx.otel);
-
       if (!span.isExisting) {
         // FUTURE add http.server.request.duration
         span.setAttributes(
@@ -81,6 +79,8 @@ export const winterCgHandler = (
           err,
         });
 
+        // On error we may not reach the handler's own ctx.otel flush, so flush here.
+        span.setAttributes(ctx.otel);
         span.recordError(err, true);
       }
       span.setAttributes({ "http.response.status_code_effective": realStatus });


### PR DESCRIPTION
## Summary

- Flush `ctx.otel` to the span in `finalize()`, ensuring hook-written attributes are always exported regardless of where in the handler lifecycle an error occurs

Closes #211
Ref: https://github.com/8monkey-ai/hebo-platform/issues/465

## Test plan

- [x] New test in `src/lifecycle.test.ts` verifies attributes set on `ctx.otel` appear on the exported span when the handler throws
- [x] Test fails without the fix (`Received: undefined`), passes with it
- [x] Full test suite passes (662 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)