### PR TITLE
fix(stream): preserve upstream error message across all SSE endpoints

### DIFF
--- a/src/endpoints/chat-completions/converters.test.ts
+++ b/src/endpoints/chat-completions/converters.test.ts
@@ -8,6 +8,7 @@ import type {
   FilePart,
   LanguageModelUsage,
   AssistantModelMessage,
+  TextStreamPart,
 } from "ai";
 
 import {
@@ -18,6 +19,7 @@ import {
   toChatCompletionsUsage,
   fromChatCompletionsAssistantMessage,
   fromChatCompletionsToolResultMessage,
+  ChatCompletionsTransformStream,
 } from "./converters";
 import type { ChatCompletionsToolMessage } from "./schema";
 
@@ -929,6 +931,94 @@ describe("Chat Completions Converters", () => {
       const call = toChatCompletionsToolCall("call_1", "a".repeat(200), {});
       expect(call.function.name).toHaveLength(128);
       expect(call.function.name).toBe("a".repeat(128));
+    });
+  });
+
+  describe("ChatCompletionsTransformStream error handling", () => {
+    const collectErrorData = async (
+      stream: ReadableStream<TextStreamPart<ToolSet>>,
+    ): Promise<Error | undefined> => {
+      const transformed = stream.pipeThrough(new ChatCompletionsTransformStream("test-model"));
+      const reader = transformed.getReader();
+      while (true) {
+        // oxlint-disable-next-line no-await-in-loop
+        const { done, value } = await reader.read();
+        if (done) return undefined;
+        if (value && value.data instanceof Error) {
+          return value.data;
+        }
+      }
+    };
+
+    test("should preserve message from plain object error payloads", async () => {
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "error",
+            error: {
+              type: "invalid_request_error",
+              message:
+                "Unable to submit request because function call `check_availability` is missing a `thought_signature`.",
+            },
+          });
+          controller.close();
+        },
+      });
+
+      const error = await collectErrorData(stream);
+      expect(error).toBeInstanceOf(Error);
+      expect(error!.message).toBe(
+        "Unable to submit request because function call `check_availability` is missing a `thought_signature`.",
+      );
+    });
+
+    test("should fall back to JSON.stringify for opaque object errors", async () => {
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "error",
+            error: { code: 42, detail: "no message field" },
+          });
+          controller.close();
+        },
+      });
+
+      const error = await collectErrorData(stream);
+      expect(error).toBeInstanceOf(Error);
+      expect(error!.message).toBe(JSON.stringify({ code: 42, detail: "no message field" }));
+      expect(error!.message).not.toBe("[object Object]");
+    });
+
+    test("should handle string error payloads", async () => {
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "error",
+            error: "raw string error",
+          });
+          controller.close();
+        },
+      });
+
+      const error = await collectErrorData(stream);
+      expect(error).toBeInstanceOf(Error);
+      expect(error!.message).toBe("raw string error");
+    });
+
+    test("should pass through Error instances unchanged", async () => {
+      const original = new Error("Something went wrong");
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "error",
+            error: original,
+          });
+          controller.close();
+        },
+      });
+
+      const error = await collectErrorData(stream);
+      expect(error).toBe(original);
     });
   });
 });

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -34,6 +34,7 @@ import {
   parseBase64,
   parseImageInput,
   extractReasoningMetadata,
+  extractStreamErrorFields,
   type TextCallOptions,
   type ToolChoiceOptions,
 } from "../shared/converters";
@@ -634,9 +635,11 @@ export class ChatCompletionsTransformStream extends TransformStream<
           }
 
           case "error": {
-            controller.enqueue({
-              data: part.error instanceof Error ? part.error : new Error(String(part.error)),
-            });
+            const data =
+              part.error instanceof Error
+                ? part.error
+                : new Error(extractStreamErrorFields(part.error).message);
+            controller.enqueue({ data });
           }
         }
       },

--- a/src/endpoints/messages/converters.test.ts
+++ b/src/endpoints/messages/converters.test.ts
@@ -1482,5 +1482,81 @@ describe("Messages Converters", () => {
           .error.message,
       ).toBe("Something went wrong");
     });
+
+    test("should preserve message and type from plain object error payloads", async () => {
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "error",
+            error: {
+              type: "invalid_request_error",
+              message:
+                "Unable to submit request because function call `check_availability` is missing a `thought_signature`.",
+            },
+          });
+          controller.close();
+        },
+      });
+
+      const transformed = stream.pipeThrough(new MessagesTransformStream("test-model"));
+      const { events } = await collectStreamEvents(transformed);
+
+      const errorEvent = events.find((e) => e.event === "error");
+      expect(errorEvent).toBeDefined();
+      const data = (
+        errorEvent as { data: { type: string; error: { type: string; message: string } } }
+      ).data;
+      expect(data.error.type).toBe("invalid_request_error");
+      expect(data.error.message).toBe(
+        "Unable to submit request because function call `check_availability` is missing a `thought_signature`.",
+      );
+    });
+
+    test("should fall back to JSON.stringify for opaque object errors", async () => {
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "error",
+            error: { code: 42, detail: "no message field" },
+          });
+          controller.close();
+        },
+      });
+
+      const transformed = stream.pipeThrough(new MessagesTransformStream("test-model"));
+      const { events } = await collectStreamEvents(transformed);
+
+      const errorEvent = events.find((e) => e.event === "error");
+      expect(errorEvent).toBeDefined();
+      const data = (
+        errorEvent as { data: { type: string; error: { type: string; message: string } } }
+      ).data;
+      expect(data.error.type).toBe("api_error");
+      expect(data.error.message).toBe(JSON.stringify({ code: 42, detail: "no message field" }));
+      expect(data.error.message).not.toBe("[object Object]");
+    });
+
+    test("should handle string error payloads", async () => {
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "error",
+            error: "raw string error",
+          });
+          controller.close();
+        },
+      });
+
+      const transformed = stream.pipeThrough(new MessagesTransformStream("test-model"));
+      const { events } = await collectStreamEvents(transformed);
+
+      const errorEvent = events.find((e) => e.event === "error");
+      expect(errorEvent).toBeDefined();
+      const data = (
+        errorEvent as { data: { type: string; error: { type: string; message: string } } }
+      ).data;
+      expect(data.error.type).toBe("api_error");
+      expect(data.error.message).toBe("raw string error");
+    });
   });
 });

--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -27,6 +27,7 @@ import {
   stripEmptyKeys,
   resolveResponseServiceTier,
   extractReasoningMetadata,
+  extractStreamErrorFields,
   parseJsonOrText,
   type TextCallOptions,
 } from "../shared/converters";
@@ -791,12 +792,12 @@ export class MessagesTransformStream extends TransformStream<
           }
 
           case "error": {
-            const message = part.error instanceof Error ? part.error.message : String(part.error);
+            const { type, message } = extractStreamErrorFields(part.error);
             controller.enqueue({
               event: "error",
               data: {
                 type: "error",
-                error: { type: "api_error", message },
+                error: { type, message },
               },
             });
             break;

--- a/src/endpoints/responses/converters.test.ts
+++ b/src/endpoints/responses/converters.test.ts
@@ -8,6 +8,7 @@ import type {
   UserModelMessage,
   FilePart,
   ToolModelMessage,
+  TextStreamPart,
 } from "ai";
 
 import {
@@ -964,6 +965,92 @@ describe("Responses Converters", () => {
       expect(toolCallDoneEvent).toBeDefined();
       const item = toolCallDoneEvent!.data.item as ResponsesFunctionCall;
       expect(item.extra_content).toEqual({ test: { final: "metadata" } });
+    });
+
+    const collectErrorData = async (
+      stream: ReadableStream<TextStreamPart<ToolSet>>,
+    ): Promise<Error | undefined> => {
+      const transformed = stream.pipeThrough(new ResponsesTransformStream("test-model"));
+      const reader = transformed.getReader();
+      while (true) {
+        // oxlint-disable-next-line no-await-in-loop
+        const { done, value } = await reader.read();
+        if (done) return undefined;
+        if (value && (value as { data?: unknown }).data instanceof Error) {
+          return (value as { data: Error }).data;
+        }
+      }
+    };
+
+    test("should preserve message from plain object error payloads", async () => {
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "error",
+            error: {
+              type: "invalid_request_error",
+              message:
+                "Unable to submit request because function call `check_availability` is missing a `thought_signature`.",
+            },
+          });
+          controller.close();
+        },
+      });
+
+      const error = await collectErrorData(stream);
+      expect(error).toBeInstanceOf(Error);
+      expect(error!.message).toBe(
+        "Unable to submit request because function call `check_availability` is missing a `thought_signature`.",
+      );
+    });
+
+    test("should fall back to JSON.stringify for opaque object errors", async () => {
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "error",
+            error: { code: 42, detail: "no message field" },
+          });
+          controller.close();
+        },
+      });
+
+      const error = await collectErrorData(stream);
+      expect(error).toBeInstanceOf(Error);
+      expect(error!.message).toBe(JSON.stringify({ code: 42, detail: "no message field" }));
+      expect(error!.message).not.toBe("[object Object]");
+    });
+
+    test("should handle string error payloads", async () => {
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "error",
+            error: "raw string error",
+          });
+          controller.close();
+        },
+      });
+
+      const error = await collectErrorData(stream);
+      expect(error).toBeInstanceOf(Error);
+      expect(error!.message).toBe("raw string error");
+    });
+
+    test("should pass through Error instances unchanged", async () => {
+      const original = new Error("Something went wrong");
+      const stream = new ReadableStream<TextStreamPart<ToolSet>>({
+        start(controller) {
+          controller.enqueue({
+            type: "error",
+            error: original,
+          });
+          controller.close();
+        },
+      });
+
+      const error = await collectErrorData(stream);
+      expect(error).toBe(original);
     });
   });
 });

--- a/src/endpoints/responses/converters.ts
+++ b/src/endpoints/responses/converters.ts
@@ -34,6 +34,7 @@ import {
   parseBase64,
   parseImageInput,
   extractReasoningMetadata,
+  extractStreamErrorFields,
   type TextCallOptions,
   type ToolChoiceOptions,
 } from "../shared/converters";
@@ -1366,9 +1367,11 @@ export class ResponsesTransformStream extends TransformStream<
           }
 
           case "error": {
-            controller.enqueue({
-              data: part.error instanceof Error ? part.error : new Error(String(part.error)),
-            });
+            const data =
+              part.error instanceof Error
+                ? part.error
+                : new Error(extractStreamErrorFields(part.error).message);
+            controller.enqueue({ data });
             break;
           }
         }

--- a/src/endpoints/shared/converters.ts
+++ b/src/endpoints/shared/converters.ts
@@ -228,6 +228,32 @@ export function stripEmptyKeys(obj: unknown) {
   return obj;
 }
 
+// Upstream stream errors arrive in three shapes: `Error` instances, raw strings,
+// or plain JSON payloads (e.g. Google's `{ type, message }` from a 4xx response).
+// Plain `String(obj)` collapses the last case to "[object Object]", losing both
+// the upstream `type` and the human-readable message.
+export function extractStreamErrorFields(error: unknown): { type: string; message: string } {
+  if (error instanceof Error) {
+    return { type: "api_error", message: error.message };
+  }
+  if (typeof error === "string") {
+    return { type: "api_error", message: error };
+  }
+  if (error && typeof error === "object") {
+    const obj = error as { type?: unknown; message?: unknown };
+    const type = typeof obj.type === "string" ? obj.type : "api_error";
+    const message =
+      typeof obj.message === "string" && obj.message.length > 0
+        ? obj.message
+        : JSON.stringify(error);
+    return { type, message };
+  }
+  return {
+    type: "api_error",
+    message: error === null || error === undefined ? "unknown error" : JSON.stringify(error),
+  };
+}
+
 export function extractReasoningMetadata(providerMetadata?: SharedV3ProviderMetadata): {
   redactedData?: string;
   signature?: string;


### PR DESCRIPTION
Closes #213

## Summary

The streaming error event in `/v1/messages`, `/v1/chat/completions`, and `/v1/responses` was serializing non-Error payloads via `String(obj)`, producing `"[object Object]"` and discarding the upstream's original message (and, on the Anthropic path, the `type`). Providers such as `@ai-sdk/google` enqueue stream errors as plain JSON payloads (`{ type, message }`), which fell through the existing branches.

- Lifted `extractStreamErrorFields` into `src/endpoints/shared/converters.ts`.
- `messages` preserves both `type` and `message` (matches Anthropic's wire format).
- `chat-completions` and `responses` wrap the extracted message with `new Error(message)) so the existing `toOpenAIError` path keeps working unchanged (`type` there comes from HTTP status, not the payload).
- Opaque object payloads fall back to `JSON.stringify` rather than the literal `[object Object]`.

## Test plan

- [x] `bun test --parallel src/` — 673/673 pass
- [x] New parallel tests in each endpoint's test file cover plain-object, opaque-object, string, and (for OpenAI-style endpoints) Error pass-through
- [ ] Reproduce the original curl against a Google provider on each endpoint and confirm the SSE `error` event now carries the full upstream message

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for streaming responses to ensure more consistent and reliable error messages across all API endpoints.
  * Enhanced error message processing to correctly interpret and format various types of error information in streaming operations.
  * Strengthened error resilience with additional edge case handling.
  * Expanded test coverage for streaming error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/8monkey-ai/hebo-gateway/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->