### PR TITLE
fix: pass adaptive thinking through to Claude on Bedrock

### DIFF
--- a/src/providers/bedrock/middleware.test.ts
+++ b/src/providers/bedrock/middleware.test.ts
@@ -136,7 +136,7 @@ test("bedrockGptReasoningMiddleware > should skip non-gpt models", async () => {
   });
 });
 
-test("bedrockClaudeReasoningMiddleware > should map thinking/effort into reasoningConfig", async () => {
+test("bedrockClaudeReasoningMiddleware > should pass adaptive thinking through with effort", async () => {
   const params = {
     prompt: [],
     providerOptions: {
@@ -161,7 +161,7 @@ test("bedrockClaudeReasoningMiddleware > should map thinking/effort into reasoni
     providerOptions: {
       bedrock: {
         reasoningConfig: {
-          type: "enabled", // "adaptive" mapped to "enabled" — Converse API limitation
+          type: "adaptive",
           budgetTokens: 4096,
           maxReasoningEffort: "max",
         },
@@ -170,7 +170,7 @@ test("bedrockClaudeReasoningMiddleware > should map thinking/effort into reasoni
   });
 });
 
-test("bedrockClaudeReasoningMiddleware > should compute fallback budgetTokens using medium effort when adaptive mapped to enabled", async () => {
+test("bedrockClaudeReasoningMiddleware > should pass adaptive thinking without budget", async () => {
   const params = {
     prompt: [],
     maxOutputTokens: 8192,
@@ -178,6 +178,106 @@ test("bedrockClaudeReasoningMiddleware > should compute fallback budgetTokens us
       bedrock: {
         thinking: {
           type: "adaptive",
+        },
+      },
+    },
+  };
+
+  const result = await bedrockClaudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4-6" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    maxOutputTokens: 8192,
+    providerOptions: {
+      bedrock: {
+        reasoningConfig: {
+          type: "adaptive",
+        },
+      },
+    },
+  });
+});
+
+test("bedrockClaudeReasoningMiddleware > should map effort with adaptive thinking", async () => {
+  const params = {
+    prompt: [],
+    maxOutputTokens: 10000,
+    providerOptions: {
+      bedrock: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "high",
+      },
+    },
+  };
+
+  const result = await bedrockClaudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4-6" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    maxOutputTokens: 10000,
+    providerOptions: {
+      bedrock: {
+        reasoningConfig: {
+          type: "adaptive",
+          maxReasoningEffort: "high",
+        },
+      },
+    },
+  });
+});
+
+test("bedrockClaudeReasoningMiddleware > should pass max effort with adaptive thinking", async () => {
+  const params = {
+    prompt: [],
+    maxOutputTokens: 10000,
+    providerOptions: {
+      bedrock: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "max",
+      },
+    },
+  };
+
+  const result = await bedrockClaudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4-6" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    maxOutputTokens: 10000,
+    providerOptions: {
+      bedrock: {
+        reasoningConfig: {
+          type: "adaptive",
+          maxReasoningEffort: "max",
+        },
+      },
+    },
+  });
+});
+
+test("bedrockClaudeReasoningMiddleware > should compute fallback budgetTokens using medium effort when type is enabled", async () => {
+  const params = {
+    prompt: [],
+    maxOutputTokens: 8192,
+    providerOptions: {
+      bedrock: {
+        thinking: {
+          type: "enabled",
         },
       },
     },
@@ -204,117 +304,14 @@ test("bedrockClaudeReasoningMiddleware > should compute fallback budgetTokens us
   });
 });
 
-test("bedrockClaudeReasoningMiddleware > should use effort for fallback budgetTokens when effort is available", async () => {
-  const params = {
-    prompt: [],
-    maxOutputTokens: 10000,
-    providerOptions: {
-      bedrock: {
-        thinking: {
-          type: "adaptive",
-        },
-        effort: "high",
-      },
-    },
-  };
-
-  const result = await bedrockClaudeReasoningMiddleware.transformParams!({
-    type: "generate",
-    params,
-    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4-6" }),
-  });
-
-  // high effort = 80% of maxOutputTokens
-  expect(result).toEqual({
-    prompt: [],
-    maxOutputTokens: 10000,
-    providerOptions: {
-      bedrock: {
-        reasoningConfig: {
-          type: "enabled",
-          budgetTokens: 8000,
-          maxReasoningEffort: "high",
-        },
-      },
-    },
-  });
-});
-
-test("bedrockClaudeReasoningMiddleware > should map max effort to xhigh for fallback budgetTokens", async () => {
-  const params = {
-    prompt: [],
-    maxOutputTokens: 10000,
-    providerOptions: {
-      bedrock: {
-        thinking: {
-          type: "adaptive",
-        },
-        effort: "max",
-      },
-    },
-  };
-
-  const result = await bedrockClaudeReasoningMiddleware.transformParams!({
-    type: "generate",
-    params,
-    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4-6" }),
-  });
-
-  // max → xhigh effort = 95% of maxOutputTokens
-  expect(result).toEqual({
-    prompt: [],
-    maxOutputTokens: 10000,
-    providerOptions: {
-      bedrock: {
-        reasoningConfig: {
-          type: "enabled",
-          budgetTokens: 9500,
-          maxReasoningEffort: "max",
-        },
-      },
-    },
-  });
-});
-
-test("bedrockClaudeReasoningMiddleware > should use default maxOutputTokens for fallback budgetTokens", async () => {
-  const params = {
-    prompt: [],
-    providerOptions: {
-      bedrock: {
-        thinking: {
-          type: "adaptive",
-        },
-      },
-    },
-  };
-
-  const result = await bedrockClaudeReasoningMiddleware.transformParams!({
-    type: "generate",
-    params,
-    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-4-6" }),
-  });
-
-  expect(result).toEqual({
-    prompt: [],
-    providerOptions: {
-      bedrock: {
-        reasoningConfig: {
-          type: "enabled",
-          budgetTokens: 32768, // medium effort (50%) of default 65536
-        },
-      },
-    },
-  });
-});
-
-test("bedrockClaudeReasoningMiddleware > should enforce minimum budgetTokens of 1024", async () => {
+test("bedrockClaudeReasoningMiddleware > should enforce minimum budgetTokens of 1024 for enabled", async () => {
   const params = {
     prompt: [],
     maxOutputTokens: 100,
     providerOptions: {
       bedrock: {
         thinking: {
-          type: "adaptive",
+          type: "enabled",
         },
       },
     },
@@ -385,7 +382,7 @@ test("bedrock middlewares > matching provider resolves Claude middleware for Opu
   expect(middleware).toContain(bedrockServiceTierMiddleware);
 });
 
-test("bedrockClaudeReasoningMiddleware > should set maxReasoningEffort for Claude Opus 4.7", async () => {
+test("bedrockClaudeReasoningMiddleware > should set adaptive type and maxReasoningEffort for Claude Opus 4.7", async () => {
   const params = {
     prompt: [],
     providerOptions: {
@@ -409,8 +406,7 @@ test("bedrockClaudeReasoningMiddleware > should set maxReasoningEffort for Claud
     providerOptions: {
       bedrock: {
         reasoningConfig: {
-          type: "enabled",
-          budgetTokens: 62259,
+          type: "adaptive",
           maxReasoningEffort: "xhigh",
         },
       },

--- a/src/providers/bedrock/middleware.ts
+++ b/src/providers/bedrock/middleware.ts
@@ -86,20 +86,16 @@ export const bedrockClaudeReasoningMiddleware: LanguageModelMiddleware = {
     const target = ((bedrock as BedrockProviderOptions).reasoningConfig ??= {});
 
     if (thinking && typeof thinking === "object") {
-      // Bedrock's InvokeModel (Messages) API supports "adaptive" thinking natively,
-      // but @ai-sdk/amazon-bedrock only uses the Converse API which rejects "adaptive"
-      // in additionalModelRequestFields — it only accepts "enabled" / "disabled".
-      // Map "adaptive" → "enabled" until the SDK adds InvokeModel support.
-      // See: https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-adaptive-thinking.html
-      // SDK tracking issue: https://github.com/vercel/ai/issues/8513
-      target.type = thinking.type === "adaptive" ? "enabled" : thinking.type;
+      // Bedrock Converse API supports "adaptive" natively for Claude Opus 4.6/4.7
+      // and Sonnet 4.6 via additionalModelRequestFields. Opus 4.7 *only* supports
+      // adaptive — "enabled" returns a 400.
+      // https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-adaptive-thinking.html
+      target.type = thinking.type;
       if ("budgetTokens" in thinking && thinking.budgetTokens !== undefined) {
         target.budgetTokens = thinking.budgetTokens;
       } else if (target.type === "enabled") {
-        // Bedrock requires budgetTokens when type is "enabled". When mapping from
-        // "adaptive" (which doesn't require budgetTokens), compute a fallback using
-        // the same effort-based logic as other model cases, defaulting to "medium".
-        // Note: Bedrock Converse API doesn't support "adaptive" natively — see vercel/ai#8513
+        // Bedrock requires budgetTokens when type is "enabled" — compute a fallback
+        // from effort, defaulting to "medium".
         const mappedEffort: ChatCompletionsReasoningEffort =
           effort === "max" ? "xhigh" : ((effort as ChatCompletionsReasoningEffort) ?? "medium");
         target.budgetTokens = calculateReasoningBudgetFromEffort(


### PR DESCRIPTION
Fixes #216

## Summary
Bedrock Converse API supports `thinking.type: "adaptive"` natively for Claude Opus 4.6/4.7 and Sonnet 4.6. Opus 4.7 *only* supports adaptive — manual extended thinking returns a 400. `bedrockClaudeReasoningMiddleware` was unconditionally rewriting `adaptive` to `enabled` with a synthesized budget, breaking Opus 4.7 entirely. This PR passes `thinking.type` through unchanged; the `enabled`-branch fallback budget synthesis is preserved for older Claude models.

## Test plan
- [x] `bun test src/providers/bedrock/` passes
- [x] `bun test src/` — 662 pass, 0 fail
- [ ] Manual repro against a Bedrock account with Opus 4.7 access

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Bedrock Claude adaptive thinking configuration to correctly map reasoning parameters. Adaptive thinking now properly assigns reasoning type and conditionally applies budget tokens and maximum reasoning effort based on model capabilities and user input, with improved support for newer Claude models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/8monkey-ai/hebo-gateway/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->