### PR TITLE
fix(messages): add extra_body support and switch to looseObject

### DIFF
--- a/src/endpoints/messages/converters.ts
+++ b/src/endpoints/messages/converters.ts
@@ -53,58 +53,65 @@ import type {
 // --- Request Flow ---
 
 export function convertToTextCallOptions(inputs: MessagesInputs): TextCallOptions {
+  const {
+    messages,
+    system,
+    max_tokens,
+    temperature,
+    top_p,
+    stop_sequences,
+    tools,
+    tool_choice,
+    thinking,
+    metadata,
+    service_tier,
+    cache_control,
+    output_config,
+    extra_body,
+    ...rest
+  } = inputs;
+
+  Object.assign(rest, convertThinkingToReasoning(thinking, output_config));
+
+  if (cache_control) {
+    Object.assign(rest, parsePromptCachingOptions(undefined, undefined, cache_control));
+  }
+
+  if (metadata) {
+    Object.assign(rest, { metadata });
+  }
+
+  if (service_tier) {
+    Object.assign(rest, { service_tier: toInternalServiceTier(service_tier) });
+  }
+
+  if (extra_body) {
+    for (const v of Object.values(extra_body)) {
+      Object.assign(rest, v);
+    }
+  }
+
   const options: TextCallOptions = {
-    messages: convertToModelMessages(inputs.messages, inputs.system),
-    temperature: inputs.temperature,
-    maxOutputTokens: inputs.max_tokens,
-    topP: inputs.top_p,
-    stopSequences: inputs.stop_sequences,
-    providerOptions: {},
+    messages: convertToModelMessages(messages, system),
+    temperature,
+    maxOutputTokens: max_tokens,
+    topP: top_p,
+    stopSequences: stop_sequences,
+    providerOptions: {
+      unknown: rest,
+    },
   };
 
   // Tools
-  const toolSet = convertToToolSet(inputs.tools);
+  const toolSet = convertToToolSet(tools);
   if (toolSet) options.tools = toolSet;
 
-  const toolChoice = convertToToolChoiceOptions(inputs.tool_choice);
-  if (toolChoice) options.toolChoice = toolChoice;
-
-  // Build providerOptions.unknown in one pass — reasoning, cache control, metadata,
-  // and service tier all go into the same object for middleware consumption.
-  const unknown: Record<string, unknown> = {};
-
-  // Thinking/reasoning — convert to the shared `reasoning` config format so the
-  // model middleware (claudeReasoningMiddleware) and provider middleware
-  // (bedrockClaudeReasoningMiddleware) handle provider-specific conversion.
-  const reasoningResult = convertThinkingToReasoning(inputs.thinking, inputs.output_config);
-  if (reasoningResult) {
-    unknown["reasoning"] = reasoningResult.reasoning;
-    unknown["reasoning_effort"] = reasoningResult.reasoning_effort;
-  }
-
-  // Per-block cache control is handled in convertToModelMessages.
-  // Top-level automatic caching:
-  if (inputs.cache_control) {
-    Object.assign(unknown, parsePromptCachingOptions(undefined, undefined, inputs.cache_control));
-  }
-
-  // Metadata passthrough
-  if (inputs.metadata) {
-    unknown["metadata"] = inputs.metadata;
-  }
-
-  // Service tier — map Anthropic-native values to internal representation
-  if (inputs.service_tier) {
-    unknown["service_tier"] = toInternalServiceTier(inputs.service_tier);
-  }
-
-  if (Object.keys(unknown).length > 0) {
-    (options.providerOptions as Record<string, unknown>)["unknown"] = unknown;
-  }
+  const toolChoiceOpts = convertToToolChoiceOptions(tool_choice);
+  if (toolChoiceOpts) options.toolChoice = toolChoiceOpts;
 
   // Structured output
-  if (inputs.output_config) {
-    options.output = convertToOutput(inputs.output_config);
+  if (output_config) {
+    options.output = convertToOutput(output_config);
   }
 
   return options;

--- a/src/endpoints/messages/schema.ts
+++ b/src/endpoints/messages/schema.ts
@@ -231,13 +231,10 @@ export type MessagesOutputConfig = z.infer<typeof MessagesOutputConfigSchema>;
 
 // --- Request Body Schema ---
 
-export const MessagesBodySchema = z.object({
-  model: z.string(),
+const MessagesInputsSchema = z.object({
   max_tokens: z.number().int().min(1),
   messages: z.array(MessagesMessageSchema),
   system: z.union([z.string(), z.array(SystemBlockSchema)]).optional(),
-  stream: z.boolean().optional(),
-  trace: TraceSchema,
   temperature: z.number().optional(),
   top_p: z.number().optional(),
   stop_sequences: z.array(z.string()).optional(),
@@ -248,9 +245,19 @@ export const MessagesBodySchema = z.object({
   service_tier: MessagesServiceTierSchema.optional(),
   cache_control: CacheControlSchema.optional(),
   output_config: MessagesOutputConfigSchema.optional(),
+  // Extension origin: Gemini extra_body
+  // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/migrate/openai/overview#extra_body
+  extra_body: ProviderMetadataSchema.optional().meta({ extension: true }),
+});
+export type MessagesInputs = z.infer<typeof MessagesInputsSchema>;
+
+export const MessagesBodySchema = z.looseObject({
+  model: z.string(),
+  stream: z.boolean().optional(),
+  trace: TraceSchema,
+  ...MessagesInputsSchema.shape,
 });
 export type MessagesBody = z.infer<typeof MessagesBodySchema>;
-export type MessagesInputs = Omit<MessagesBody, "model" | "stream">;
 
 // --- Response Schemas ---
 


### PR DESCRIPTION
## Summary

- Adds `extra_body` field to `/v1/messages`, forwarding provider-specific parameters (e.g. Vertex `labels` for billing attribution) to downstream providers — consistent with `/v1/chat/completions` and `/v1/responses`.
- Switches `MessagesBodySchema` from `z.object` to `z.looseObject`, so arbitrary top-level fields are no longer silently stripped at parse time. This mirrors the chat-completions schema structure.
- Refactors the messages converter to use destructuring with `...rest`, matching the chat-completions pattern where arbitrary fields flow through to `providerOptions.unknown`.

## Changes

| File | What |
|------|------|
| `src/endpoints/messages/schema.ts` | Split into `MessagesInputsSchema` (strict) + `MessagesBodySchema` (`z.looseObject` wrapping it); added `extra_body` field |
| `src/endpoints/messages/converters.ts` | Restructured to destructure inputs + `...rest`, merge `extra_body` and known options into `rest`, pass as `providerOptions: { unknown: rest }` |

## Test plan

- [x] `npx tsc --noEmit` — zero errors in `src/`
- [x] `bun test src/endpoints/messages/` — 134 tests pass
- [x] Full suite — 781 pass, 30 skip, 1 pre-existing unrelated failure

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal message input handling and schema definitions to improve code maintainability and composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->