### PR TITLE
feat: support unified metadata labels across providers

### DIFF
--- a/src/endpoints/messages/converters.test.ts
+++ b/src/endpoints/messages/converters.test.ts
@@ -1099,6 +1099,19 @@ describe("Messages Converters", () => {
       });
     });
 
+    test("should pass arbitrary metadata labels in providerOptions", () => {
+      const result = convertToTextCallOptions({
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 1000,
+        metadata: { user_id: "u-123", cost_center: "abc", team: "core" },
+      });
+      expect((result.providerOptions["unknown"] as Record<string, unknown>)["metadata"]).toEqual({
+        user_id: "u-123",
+        cost_center: "abc",
+        team: "core",
+      });
+    });
+
     test("should map service_tier 'auto' to internal 'auto'", () => {
       const result = convertToTextCallOptions({
         messages: [{ role: "user", content: "Hi" }],

--- a/src/endpoints/messages/converters.test.ts
+++ b/src/endpoints/messages/converters.test.ts
@@ -1092,17 +1092,6 @@ describe("Messages Converters", () => {
       const result = convertToTextCallOptions({
         messages: [{ role: "user", content: "Hi" }],
         max_tokens: 1000,
-        metadata: { user_id: "u-123" },
-      });
-      expect((result.providerOptions["unknown"] as Record<string, unknown>)["metadata"]).toEqual({
-        user_id: "u-123",
-      });
-    });
-
-    test("should pass arbitrary metadata labels in providerOptions", () => {
-      const result = convertToTextCallOptions({
-        messages: [{ role: "user", content: "Hi" }],
-        max_tokens: 1000,
         metadata: { user_id: "u-123", cost_center: "abc", team: "core" },
       });
       expect((result.providerOptions["unknown"] as Record<string, unknown>)["metadata"]).toEqual({

--- a/src/endpoints/messages/schema.ts
+++ b/src/endpoints/messages/schema.ts
@@ -244,7 +244,7 @@ export const MessagesBodySchema = z.object({
   tools: z.array(MessagesToolSchema).optional(),
   tool_choice: MessagesToolChoiceSchema.optional(),
   thinking: MessagesThinkingConfigSchema.nullish(),
-  metadata: z.object({ user_id: z.string().optional() }).optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
   service_tier: MessagesServiceTierSchema.optional(),
   cache_control: CacheControlSchema.optional(),
   output_config: MessagesOutputConfigSchema.optional(),

--- a/src/providers/vertex/middleware.test.ts
+++ b/src/providers/vertex/middleware.test.ts
@@ -115,18 +115,3 @@ test("vertexMetadataMiddleware > leaves params untouched without metadata", asyn
 
   expect(result.providerOptions!["vertex"]).toEqual({ labels: { env: "prod" } });
 });
-
-test("vertexMetadataMiddleware > ignores non-object metadata", async () => {
-  const result = await transformMetadata({ metadata: "not-an-object", labels: { env: "prod" } });
-
-  expect(result.providerOptions!["vertex"]).toEqual({
-    metadata: "not-an-object",
-    labels: { env: "prod" },
-  });
-});
-
-test("vertexMetadataMiddleware > drops non-object labels when merging", async () => {
-  const result = await transformMetadata({ metadata: { team: "core" }, labels: "bogus" });
-
-  expect(result.providerOptions!["vertex"]).toEqual({ labels: { team: "core" } });
-});

--- a/src/providers/vertex/middleware.test.ts
+++ b/src/providers/vertex/middleware.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 
 import { MockLanguageModelV3 } from "ai/test";
 
-import { vertexServiceTierMiddleware } from "./middleware";
+import { vertexMetadataMiddleware, vertexServiceTierMiddleware } from "./middleware";
 
 const vertexServiceTierCases = [
   {
@@ -84,4 +84,34 @@ test("vertexServiceTierMiddleware > should not override pre-set headers", async 
     "x-vertex-ai-llm-shared-request-type": "priority",
   });
   expect(result.providerOptions!["vertex"]).toEqual({});
+});
+
+const transformMetadata = (vertex: Record<string, unknown>) =>
+  vertexMetadataMiddleware.transformParams!({
+    type: "generate",
+    params: { prompt: [], providerOptions: { vertex } as never },
+    model: new MockLanguageModelV3({ modelId: "google/gemini-2.5-pro" }),
+  });
+
+test("vertexMetadataMiddleware > translates metadata into labels", async () => {
+  const result = await transformMetadata({ metadata: { team: "core" } });
+
+  expect(result.providerOptions!["vertex"]).toEqual({ labels: { team: "core" } });
+});
+
+test("vertexMetadataMiddleware > merges metadata over existing labels", async () => {
+  const result = await transformMetadata({
+    metadata: { team: "core" },
+    labels: { env: "prod" },
+  });
+
+  expect(result.providerOptions!["vertex"]).toEqual({
+    labels: { env: "prod", team: "core" },
+  });
+});
+
+test("vertexMetadataMiddleware > leaves params untouched without metadata", async () => {
+  const result = await transformMetadata({ labels: { env: "prod" } });
+
+  expect(result.providerOptions!["vertex"]).toEqual({ labels: { env: "prod" } });
 });

--- a/src/providers/vertex/middleware.test.ts
+++ b/src/providers/vertex/middleware.test.ts
@@ -86,23 +86,24 @@ test("vertexServiceTierMiddleware > should not override pre-set headers", async 
   expect(result.providerOptions!["vertex"]).toEqual({});
 });
 
-const transformMetadata = (vertex: Record<string, unknown>) =>
-  vertexMetadataMiddleware.transformParams!({
+test("vertexMetadataMiddleware > translates metadata into labels", async () => {
+  const result = await vertexMetadataMiddleware.transformParams!({
     type: "generate",
-    params: { prompt: [], providerOptions: { vertex } as never },
+    params: { prompt: [], providerOptions: { vertex: { metadata: { team: "core" } } } },
     model: new MockLanguageModelV3({ modelId: "google/gemini-2.5-pro" }),
   });
-
-test("vertexMetadataMiddleware > translates metadata into labels", async () => {
-  const result = await transformMetadata({ metadata: { team: "core" } });
 
   expect(result.providerOptions!["vertex"]).toEqual({ labels: { team: "core" } });
 });
 
 test("vertexMetadataMiddleware > merges metadata over existing labels", async () => {
-  const result = await transformMetadata({
-    metadata: { team: "core" },
-    labels: { env: "prod" },
+  const result = await vertexMetadataMiddleware.transformParams!({
+    type: "generate",
+    params: {
+      prompt: [],
+      providerOptions: { vertex: { metadata: { team: "core" }, labels: { env: "prod" } } },
+    },
+    model: new MockLanguageModelV3({ modelId: "google/gemini-2.5-pro" }),
   });
 
   expect(result.providerOptions!["vertex"]).toEqual({
@@ -111,7 +112,11 @@ test("vertexMetadataMiddleware > merges metadata over existing labels", async ()
 });
 
 test("vertexMetadataMiddleware > leaves params untouched without metadata", async () => {
-  const result = await transformMetadata({ labels: { env: "prod" } });
+  const result = await vertexMetadataMiddleware.transformParams!({
+    type: "generate",
+    params: { prompt: [], providerOptions: { vertex: { labels: { env: "prod" } } } },
+    model: new MockLanguageModelV3({ modelId: "google/gemini-2.5-pro" }),
+  });
 
   expect(result.providerOptions!["vertex"]).toEqual({ labels: { env: "prod" } });
 });

--- a/src/providers/vertex/middleware.test.ts
+++ b/src/providers/vertex/middleware.test.ts
@@ -115,3 +115,18 @@ test("vertexMetadataMiddleware > leaves params untouched without metadata", asyn
 
   expect(result.providerOptions!["vertex"]).toEqual({ labels: { env: "prod" } });
 });
+
+test("vertexMetadataMiddleware > ignores non-object metadata", async () => {
+  const result = await transformMetadata({ metadata: "not-an-object", labels: { env: "prod" } });
+
+  expect(result.providerOptions!["vertex"]).toEqual({
+    metadata: "not-an-object",
+    labels: { env: "prod" },
+  });
+});
+
+test("vertexMetadataMiddleware > drops non-object labels when merging", async () => {
+  const result = await transformMetadata({ metadata: { team: "core" }, labels: "bogus" });
+
+  expect(result.providerOptions!["vertex"]).toEqual({ labels: { team: "core" } });
+});

--- a/src/providers/vertex/middleware.ts
+++ b/src/providers/vertex/middleware.ts
@@ -14,6 +14,10 @@ function setHeaderIfMissing(
   headers[key] ??= value;
 }
 
+function isStringMap(v: unknown): v is Record<string, string> {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
 // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/standard-paygo
 // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo
 // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo
@@ -63,10 +67,11 @@ export const vertexMetadataMiddleware: LanguageModelMiddleware = {
     if (!vertex || typeof vertex !== "object") return params;
 
     const metadata = vertex["metadata"];
-    if (!metadata) return params;
+    if (!isStringMap(metadata)) return params;
 
-    vertex["labels"] = { ...(vertex["labels"] as object), ...(metadata as object) };
-    delete vertex["metadata"];
+    const labels = vertex["labels"];
+    vertex["labels"] = { ...(isStringMap(labels) ? labels : {}), ...metadata };
+    vertex["metadata"] = undefined;
     return params;
   },
 };

--- a/src/providers/vertex/middleware.ts
+++ b/src/providers/vertex/middleware.ts
@@ -14,10 +14,6 @@ function setHeaderIfMissing(
   headers[key] ??= value;
 }
 
-function isStringMap(v: unknown): v is Record<string, string> {
-  return !!v && typeof v === "object" && !Array.isArray(v);
-}
-
 // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/standard-paygo
 // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo
 // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo
@@ -67,10 +63,9 @@ export const vertexMetadataMiddleware: LanguageModelMiddleware = {
     if (!vertex || typeof vertex !== "object") return params;
 
     const metadata = vertex["metadata"];
-    if (!isStringMap(metadata)) return params;
+    if (!metadata) return params;
 
-    const labels = vertex["labels"];
-    vertex["labels"] = { ...(isStringMap(labels) ? labels : {}), ...metadata };
+    vertex["labels"] = { ...(vertex["labels"] as object), ...(metadata as object) };
     vertex["metadata"] = undefined;
     return params;
   },

--- a/src/providers/vertex/middleware.ts
+++ b/src/providers/vertex/middleware.ts
@@ -55,6 +55,22 @@ export const vertexServiceTierMiddleware: LanguageModelMiddleware = {
   },
 };
 
+export const vertexMetadataMiddleware: LanguageModelMiddleware = {
+  specificationVersion: "v3",
+  // eslint-disable-next-line require-await
+  transformParams: async ({ params }) => {
+    const vertex = params.providerOptions?.["vertex"];
+    if (!vertex || typeof vertex !== "object") return params;
+
+    const metadata = vertex["metadata"];
+    if (!metadata) return params;
+
+    vertex["labels"] = { ...(vertex["labels"] as object), ...(metadata as object) };
+    delete vertex["metadata"];
+    return params;
+  },
+};
+
 modelMiddlewareMatcher.useForProvider(["google.vertex.*"], {
-  language: [vertexServiceTierMiddleware],
+  language: [vertexServiceTierMiddleware, vertexMetadataMiddleware],
 });


### PR DESCRIPTION
Closes #221

## Summary

Makes the request `metadata` map a **provider-agnostic** set of billing/attribution labels. A caller sets `metadata` once and the gateway translates it into whichever native field the resolved provider expects — the same pattern already used for `service_tier`.

| Provider | Native field | Handling |
|---|---|---|
| OpenAI | `metadata` | passthrough (SDK reads it natively) |
| Vertex | `labels` | new middleware: `metadata` → `labels` |
| Bedrock | `requestMetadata` | no SDK support → silently ignored |

## Changes

- **`providers/vertex/middleware.ts`** — add `vertexMetadataMiddleware` translating `providerOptions.vertex.metadata` → `labels` (merging over any pre-set `labels`), registered alongside the existing service-tier middleware.
- **`endpoints/messages/schema.ts`** — widen `metadata` from `{ user_id }` to `z.record(z.string(), z.string())` so the Anthropic endpoint accepts arbitrary string labels too. `metadata` was already passed through verbatim by the converter, so no converter change was needed.

The chat-completions and responses endpoints already expose `metadata` and forward it untouched, so no changes there.

## Notes / scope

- **API contract change (messages):** clients can now send arbitrary string `metadata` keys where previously only `user_id` was accepted. This is a one-way widening.
- Anthropic's SDK only consumes `metadata.userId`; extra label keys are dropped by its own schema. Telemetry already emits all metadata keys as `gen_ai.request.metadata.*` span attributes.
- Request-only — `metadata`/labels are not echoed back in responses.

## Testing

- Added Vertex middleware tests (translate, merge, no-op) and a messages converter test for arbitrary labels.
- Full `src/` suite: 666 pass / 0 fail. Lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vertex requests now support custom metadata, which is merged into request labels automatically.
  * Message metadata now accepts arbitrary key-value pairs instead of only a single fixed field.

* **Bug Fixes**
  * Existing labels are preserved when metadata is added, and new metadata no longer replaces them.
  * Metadata values are forwarded consistently through message conversion and provider handling.

* **Tests**
  * Added coverage for metadata preservation, label merging, and unchanged behavior when metadata is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->