### PR TITLE
fix(vertex): map google/gemma-4-26b-a4b to its Vertex MaaS model ID

### DIFF
--- a/src/providers/vertex/canonical.ts
+++ b/src/providers/vertex/canonical.ts
@@ -6,6 +6,7 @@ import { withCanonicalIds } from "../registry";
 const MAPPING = {
   "alibaba/qwen3-235b": "qwen3-235b-a22b-instruct-2507-maas",
   "deepseek/deepseek-v3.2": "deepseek-v3.2-maas",
+  "google/gemma-4-26b-a4b": "gemma-4-26b-a4b-it-maas",
 } as const satisfies Partial<Record<CanonicalModelId, string>>;
 
 export const withCanonicalIdsForVertex = (


### PR DESCRIPTION
Fixes #227

### Problem

`google/gemma-4-26b-a4b` declares `vertex` as a provider, but chat completion requests through the gateway fail with `404 upstream_not_found`:

```
Publisher model `projects/<project>/locations/global/publishers/google/models/gemma-4-26b-a4b` was not found or your project does not have access to it.
```

On Vertex the model is only served as Model-as-a-Service under the ID `gemma-4-26b-a4b-it-maas` (Model Garden: `google/gemma-4-26b-a4b-it-maas@001`), so the canonical ID needs an explicit mapping — same convention as the existing Qwen and DeepSeek `-maas` entries.

### Change

Adds one entry to `MAPPING` in `src/providers/vertex/canonical.ts`:

```ts
"google/gemma-4-26b-a4b": "gemma-4-26b-a4b-it-maas",
```

### Verification

- Live e2e: the previously failing request (`google/gemma-4-26b-a4b` via `withCanonicalIdsForVertex`, location `global`, `/v1/chat/completions`) now returns `200` with a valid completion.
- `bun run test`: 670 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing the Vertex Gemma 4 26B model under its canonical model ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->