### PR TITLE
feat(vertex): support reasoning for google/gemma-4-26b-a4b via MaaS endpoint

### DIFF
--- a/src/models/google/presets.ts
+++ b/src/models/google/presets.ts
@@ -214,6 +214,7 @@ export const gemma426bA4b = presetFor<CanonicalModelId, CatalogModel>()(
     ...GEMMA4_BASE,
     name: "Gemma 4 26B-A4B",
     created: "2026-04-02",
+    capabilities: ["reasoning", "tool_call", "structured_output", "temperature"] as const,
     context: 262144,
     providers: ["vertex", "deepinfra"] as const satisfies readonly CanonicalProviderId[],
   } satisfies CatalogModel,
@@ -226,7 +227,11 @@ export const gemma431b = presetFor<CanonicalModelId, CatalogModel>()(
     name: "Gemma 4 31B",
     created: "2026-04-02",
     context: 262144,
-    providers: ["vertex", "deepinfra", "togetherai"] as const satisfies readonly CanonicalProviderId[],
+    providers: [
+      "vertex",
+      "deepinfra",
+      "togetherai",
+    ] as const satisfies readonly CanonicalProviderId[],
   } satisfies CatalogModel,
 );
 

--- a/src/providers/vertex/canonical.test.ts
+++ b/src/providers/vertex/canonical.test.ts
@@ -1,10 +1,18 @@
-import { expect, test } from "bun:test";
+import { afterAll, expect, test } from "bun:test";
 
 import { createVertex } from "@ai-sdk/google-vertex";
 
 import { withCanonicalIdsForVertex } from "./canonical";
 
+// The MaaS provider built inside withCanonicalIdsForVertex resolves its project
+// from GOOGLE_VERTEX_PROJECT; restore the prior value so we don't leak into other suites.
+const prevProject = process.env["GOOGLE_VERTEX_PROJECT"];
 process.env["GOOGLE_VERTEX_PROJECT"] = "test-project";
+
+afterAll(() => {
+  if (prevProject === undefined) delete process.env["GOOGLE_VERTEX_PROJECT"];
+  else process.env["GOOGLE_VERTEX_PROJECT"] = prevProject;
+});
 
 const vertex = createVertex({
   apiKey: "test-key",

--- a/src/providers/vertex/canonical.test.ts
+++ b/src/providers/vertex/canonical.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+
+import { createVertex } from "@ai-sdk/google-vertex";
+import { createVertexMaas } from "@ai-sdk/google-vertex/maas";
+
+import { withCanonicalIdsForVertex } from "./canonical";
+
+const vertex = createVertex({ apiKey: "test-key", project: "test-project", location: "global" });
+const maas = createVertexMaas({ project: "test-project" });
+
+test("without maas: google/gemma-4-26b-a4b maps to the generateContent MaaS ID", () => {
+  const provider = withCanonicalIdsForVertex(vertex);
+  const model = provider.languageModel("google/gemma-4-26b-a4b");
+  expect(model.modelId).toBe("gemma-4-26b-a4b-it-maas");
+  expect(model.provider).toBe("google.vertex.chat");
+});
+
+test("with maas: google/gemma-4-26b-a4b routes to the MaaS OpenAI-compatible provider", () => {
+  const provider = withCanonicalIdsForVertex(vertex, undefined, maas);
+  const model = provider.languageModel("google/gemma-4-26b-a4b");
+  expect(model.modelId).toBe("google/gemma-4-26b-a4b-it-maas");
+  expect(model.provider).toBe("vertex.maas.chat");
+});
+
+test("with maas: other models still fall back to the native provider", () => {
+  const provider = withCanonicalIdsForVertex(vertex, undefined, maas);
+  const model = provider.languageModel("google/gemini-3-flash-preview");
+  expect(model.modelId).toBe("gemini-3-flash-preview");
+  expect(model.provider).toBe("google.vertex.chat");
+});

--- a/src/providers/vertex/canonical.test.ts
+++ b/src/providers/vertex/canonical.test.ts
@@ -1,29 +1,26 @@
 import { expect, test } from "bun:test";
 
 import { createVertex } from "@ai-sdk/google-vertex";
-import { createVertexMaas } from "@ai-sdk/google-vertex/maas";
 
 import { withCanonicalIdsForVertex } from "./canonical";
 
-const vertex = createVertex({ apiKey: "test-key", project: "test-project", location: "global" });
-const maas = createVertexMaas({ project: "test-project" });
+process.env["GOOGLE_VERTEX_PROJECT"] = "test-project";
 
-test("without maas: google/gemma-4-26b-a4b maps to the generateContent MaaS ID", () => {
-  const provider = withCanonicalIdsForVertex(vertex);
-  const model = provider.languageModel("google/gemma-4-26b-a4b");
-  expect(model.modelId).toBe("gemma-4-26b-a4b-it-maas");
-  expect(model.provider).toBe("google.vertex.chat");
+const vertex = createVertex({
+  apiKey: "test-key",
+  project: "test-project",
+  location: "us-central1",
 });
 
-test("with maas: google/gemma-4-26b-a4b routes to the MaaS OpenAI-compatible provider", () => {
-  const provider = withCanonicalIdsForVertex(vertex, undefined, maas);
+test("google/gemma-4-26b-a4b routes to the MaaS OpenAI-compatible provider", () => {
+  const provider = withCanonicalIdsForVertex(vertex);
   const model = provider.languageModel("google/gemma-4-26b-a4b");
   expect(model.modelId).toBe("google/gemma-4-26b-a4b-it-maas");
   expect(model.provider).toBe("vertex.maas.chat");
 });
 
-test("with maas: other models still fall back to the native provider", () => {
-  const provider = withCanonicalIdsForVertex(vertex, undefined, maas);
+test("other models fall back to the native provider", () => {
+  const provider = withCanonicalIdsForVertex(vertex);
   const model = provider.languageModel("google/gemini-3-flash-preview");
   expect(model.modelId).toBe("gemini-3-flash-preview");
   expect(model.provider).toBe("google.vertex.chat");

--- a/src/providers/vertex/canonical.test.ts
+++ b/src/providers/vertex/canonical.test.ts
@@ -1,18 +1,10 @@
-import { afterAll, expect, test } from "bun:test";
+import { expect, test } from "bun:test";
 
 import { createVertex } from "@ai-sdk/google-vertex";
 
 import { withCanonicalIdsForVertex } from "./canonical";
 
-// The MaaS provider built inside withCanonicalIdsForVertex resolves its project
-// from GOOGLE_VERTEX_PROJECT; restore the prior value so we don't leak into other suites.
-const prevProject = process.env["GOOGLE_VERTEX_PROJECT"];
 process.env["GOOGLE_VERTEX_PROJECT"] = "test-project";
-
-afterAll(() => {
-  if (prevProject === undefined) delete process.env["GOOGLE_VERTEX_PROJECT"];
-  else process.env["GOOGLE_VERTEX_PROJECT"] = prevProject;
-});
 
 const vertex = createVertex({
   apiKey: "test-key",

--- a/src/providers/vertex/canonical.ts
+++ b/src/providers/vertex/canonical.ts
@@ -1,4 +1,6 @@
 import type { GoogleVertexProvider } from "@ai-sdk/google-vertex";
+import type { GoogleVertexMaasProvider } from "@ai-sdk/google-vertex/maas";
+import { customProvider } from "ai";
 
 import type { CanonicalModelId, ModelId } from "../../models/types";
 import { withCanonicalIds } from "../registry";
@@ -12,11 +14,27 @@ const MAPPING = {
 export const withCanonicalIdsForVertex = (
   provider: GoogleVertexProvider,
   extraMapping?: Record<ModelId, string>,
-) =>
-  withCanonicalIds(provider, {
+  maas?: GoogleVertexMaasProvider,
+) => {
+  const base = withCanonicalIds(provider, {
     mapping: { ...MAPPING, ...extraMapping },
     options: {
       stripNamespace: true,
       normalizeDelimiters: ["anthropic"],
     },
   });
+
+  if (!maas) return base;
+
+  // Routed through the OpenAI-compatible MaaS endpoint when a MaaS provider
+  // is supplied (Gemma thinking is not exposed via generateContent).
+  // Getter so the MaaS provider settings are only resolved once called.
+  return customProvider({
+    languageModels: {
+      get "google/gemma-4-26b-a4b"() {
+        return maas.languageModel("google/gemma-4-26b-a4b-it-maas");
+      },
+    },
+    fallbackProvider: base,
+  });
+};

--- a/src/providers/vertex/canonical.ts
+++ b/src/providers/vertex/canonical.ts
@@ -8,7 +8,6 @@ import { withCanonicalIds } from "../registry";
 const MAPPING = {
   "alibaba/qwen3-235b": "qwen3-235b-a22b-instruct-2507-maas",
   "deepseek/deepseek-v3.2": "deepseek-v3.2-maas",
-  "google/gemma-4-26b-a4b": "gemma-4-26b-a4b-it-maas",
 } as const satisfies Partial<Record<CanonicalModelId, string>>;
 
 export const withCanonicalIdsForVertex = (

--- a/src/providers/vertex/canonical.ts
+++ b/src/providers/vertex/canonical.ts
@@ -1,5 +1,5 @@
 import type { GoogleVertexProvider } from "@ai-sdk/google-vertex";
-import type { GoogleVertexMaasProvider } from "@ai-sdk/google-vertex/maas";
+import { createVertexMaas } from "@ai-sdk/google-vertex/maas";
 import { customProvider } from "ai";
 
 import type { CanonicalModelId, ModelId } from "../../models/types";
@@ -14,8 +14,11 @@ const MAPPING = {
 export const withCanonicalIdsForVertex = (
   provider: GoogleVertexProvider,
   extraMapping?: Record<ModelId, string>,
-  maas?: GoogleVertexMaasProvider,
 ) => {
+  // Gemma thinking is not exposed via generateContent, so it routes through the
+  // MaaS endpoint, which serves Gemma only from the global endpoint.
+  const maas = createVertexMaas({ location: "global" });
+
   const base = withCanonicalIds(provider, {
     mapping: { ...MAPPING, ...extraMapping },
     options: {
@@ -24,11 +27,6 @@ export const withCanonicalIdsForVertex = (
     },
   });
 
-  if (!maas) return base;
-
-  // Routed through the OpenAI-compatible MaaS endpoint when a MaaS provider
-  // is supplied (Gemma thinking is not exposed via generateContent).
-  // Getter so the MaaS provider settings are only resolved once called.
   return customProvider({
     languageModels: {
       get "google/gemma-4-26b-a4b"() {

--- a/src/providers/vertex/middleware.test.ts
+++ b/src/providers/vertex/middleware.test.ts
@@ -2,7 +2,8 @@ import { expect, test } from "bun:test";
 
 import { MockLanguageModelV3 } from "ai/test";
 
-import { vertexGemmaThinkingMiddleware, vertexServiceTierMiddleware } from "./middleware";
+import { modelMiddlewareMatcher } from "../../middleware/matcher";
+import { vertexGemma4ThinkingMiddleware, vertexServiceTierMiddleware } from "./middleware";
 
 const vertexServiceTierCases = [
   {
@@ -105,8 +106,8 @@ const vertexGemmaThinkingCases = [
 ] as const;
 
 for (const { name, vertex, expected } of vertexGemmaThinkingCases) {
-  test(`vertexGemmaThinkingMiddleware > ${name}`, async () => {
-    const result = await vertexGemmaThinkingMiddleware.transformParams!({
+  test(`vertexGemma4ThinkingMiddleware > ${name}`, async () => {
+    const result = await vertexGemma4ThinkingMiddleware.transformParams!({
       type: "generate",
       params: { prompt: [], providerOptions: { vertex: structuredClone(vertex) } },
       model: new MockLanguageModelV3({ modelId: "google/gemma-4-26b-a4b-it-maas" }),
@@ -116,14 +117,14 @@ for (const { name, vertex, expected } of vertexGemmaThinkingCases) {
   });
 }
 
-test("vertexGemmaThinkingMiddleware > should not touch non-gemma models", async () => {
-  const vertex = { reasoning: { enabled: true, effort: "medium" }, reasoningEffort: "medium" };
-
-  const result = await vertexGemmaThinkingMiddleware.transformParams!({
-    type: "generate",
-    params: { prompt: [], providerOptions: { vertex: structuredClone(vertex) } },
-    model: new MockLanguageModelV3({ modelId: "openai/gpt-oss-120b-maas" }),
-  });
-
-  expect(result.providerOptions!["vertex"]).toEqual(vertex);
+test("vertexGemma4ThinkingMiddleware > is registered only for gemma-4", () => {
+  expect(modelMiddlewareMatcher.for("google/gemma-4-26b-a4b", "vertex.maas")).toContain(
+    vertexGemma4ThinkingMiddleware,
+  );
+  expect(modelMiddlewareMatcher.for("openai/gpt-oss-120b-maas", "vertex.maas")).not.toContain(
+    vertexGemma4ThinkingMiddleware,
+  );
+  expect(modelMiddlewareMatcher.for("google/gemma-3-27b", "vertex.maas")).not.toContain(
+    vertexGemma4ThinkingMiddleware,
+  );
 });

--- a/src/providers/vertex/middleware.test.ts
+++ b/src/providers/vertex/middleware.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 
 import { MockLanguageModelV3 } from "ai/test";
 
-import { vertexServiceTierMiddleware } from "./middleware";
+import { vertexGemmaThinkingMiddleware, vertexServiceTierMiddleware } from "./middleware";
 
 const vertexServiceTierCases = [
   {
@@ -84,4 +84,46 @@ test("vertexServiceTierMiddleware > should not override pre-set headers", async 
     "x-vertex-ai-llm-shared-request-type": "priority",
   });
   expect(result.providerOptions!["vertex"]).toEqual({});
+});
+
+const vertexGemmaThinkingCases = [
+  {
+    name: "enabled reasoning maps to enable_thinking: true",
+    vertex: { reasoning: { enabled: true, effort: "medium" }, reasoningEffort: "medium" },
+    expected: { chat_template_kwargs: { enable_thinking: true } },
+  },
+  {
+    name: "disabled reasoning maps to enable_thinking: false",
+    vertex: { reasoning: { enabled: false, effort: "none" }, reasoningEffort: "none" },
+    expected: { chat_template_kwargs: { enable_thinking: false } },
+  },
+  {
+    name: "no reasoning leaves params untouched",
+    vertex: { temperature: 0.5 },
+    expected: { temperature: 0.5 },
+  },
+] as const;
+
+for (const { name, vertex, expected } of vertexGemmaThinkingCases) {
+  test(`vertexGemmaThinkingMiddleware > ${name}`, async () => {
+    const result = await vertexGemmaThinkingMiddleware.transformParams!({
+      type: "generate",
+      params: { prompt: [], providerOptions: { vertex: structuredClone(vertex) } },
+      model: new MockLanguageModelV3({ modelId: "google/gemma-4-26b-a4b-it-maas" }),
+    });
+
+    expect(result.providerOptions!["vertex"]).toEqual(expected);
+  });
+}
+
+test("vertexGemmaThinkingMiddleware > should not touch non-gemma models", async () => {
+  const vertex = { reasoning: { enabled: true, effort: "medium" }, reasoningEffort: "medium" };
+
+  const result = await vertexGemmaThinkingMiddleware.transformParams!({
+    type: "generate",
+    params: { prompt: [], providerOptions: { vertex: structuredClone(vertex) } },
+    model: new MockLanguageModelV3({ modelId: "openai/gpt-oss-120b-maas" }),
+  });
+
+  expect(result.providerOptions!["vertex"]).toEqual(vertex);
 });

--- a/src/providers/vertex/middleware.test.ts
+++ b/src/providers/vertex/middleware.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 
+import type { LanguageModelV3CallOptions } from "@ai-sdk/provider";
 import { MockLanguageModelV3 } from "ai/test";
 
 import { modelMiddlewareMatcher } from "../../middleware/matcher";
@@ -127,4 +128,26 @@ test("vertexGemma4ThinkingMiddleware > is registered only for gemma-4", () => {
   expect(modelMiddlewareMatcher.for("google/gemma-3-27b", "vertex.maas")).not.toContain(
     vertexGemma4ThinkingMiddleware,
   );
+});
+
+test("vertexGemma4ThinkingMiddleware > enable_thinking reaches the provider", async () => {
+  const chain = modelMiddlewareMatcher.for("google/gemma-4-26b-a4b", "vertex.maas.chat");
+  const model = new MockLanguageModelV3({ modelId: "google/gemma-4-26b-a4b-it-maas" });
+
+  const params = await chain.reduce(
+    async (acc, { transformParams }) => {
+      const current = await acc;
+      return transformParams
+        ? transformParams({ type: "generate", params: current, model })
+        : current;
+    },
+    Promise.resolve({
+      prompt: [],
+      providerOptions: { unknown: { reasoning: { enabled: true } } },
+    } as LanguageModelV3CallOptions),
+  );
+
+  expect(params.providerOptions).toEqual({
+    vertex: { chat_template_kwargs: { enable_thinking: true } },
+  });
 });

--- a/src/providers/vertex/middleware.ts
+++ b/src/providers/vertex/middleware.ts
@@ -67,12 +67,10 @@ modelMiddlewareMatcher.useForProvider(["google.vertex.*"], {
 // any effort enables it, `none` / `enabled: false` disables it.
 // Gemma-only: other MaaS models control thinking differently
 // (gpt-oss uses reasoning_effort; the *-thinking variants are always on).
-export const vertexGemmaThinkingMiddleware: LanguageModelMiddleware = {
+export const vertexGemma4ThinkingMiddleware: LanguageModelMiddleware = {
   specificationVersion: "v3",
   // oxlint-disable-next-line require-await
-  transformParams: async ({ params, model }) => {
-    if (!model.modelId.includes("gemma")) return params;
-
+  transformParams: async ({ params }) => {
     const vertex = params.providerOptions?.["vertex"];
     if (!vertex || typeof vertex !== "object") return params;
 
@@ -89,6 +87,6 @@ export const vertexGemmaThinkingMiddleware: LanguageModelMiddleware = {
   },
 };
 
-modelMiddlewareMatcher.useForProvider(["vertex.maas.*"], {
-  language: [vertexGemmaThinkingMiddleware],
+modelMiddlewareMatcher.useForModel(["google/gemma-4-*"], {
+  language: [vertexGemma4ThinkingMiddleware],
 });

--- a/src/providers/vertex/middleware.ts
+++ b/src/providers/vertex/middleware.ts
@@ -1,6 +1,9 @@
 import type { LanguageModelMiddleware } from "ai";
 
-import type { ChatCompletionsServiceTier } from "../../endpoints/chat-completions";
+import type {
+  ChatCompletionsReasoningConfig,
+  ChatCompletionsServiceTier,
+} from "../../endpoints/chat-completions";
 import { modelMiddlewareMatcher } from "../../middleware/matcher";
 
 const VERTEX_REQUEST_TYPE_HEADER = "x-vertex-ai-llm-request-type";
@@ -57,4 +60,35 @@ export const vertexServiceTierMiddleware: LanguageModelMiddleware = {
 
 modelMiddlewareMatcher.useForProvider(["google.vertex.*"], {
   language: [vertexServiceTierMiddleware],
+});
+
+// https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/capabilities/thinking
+// Gemma thinking on the MaaS OpenAI-compatible endpoint is binary:
+// any effort enables it, `none` / `enabled: false` disables it.
+// Gemma-only: other MaaS models control thinking differently
+// (gpt-oss uses reasoning_effort; the *-thinking variants are always on).
+export const vertexGemmaThinkingMiddleware: LanguageModelMiddleware = {
+  specificationVersion: "v3",
+  // oxlint-disable-next-line require-await
+  transformParams: async ({ params, model }) => {
+    if (!model.modelId.includes("gemma")) return params;
+
+    const vertex = params.providerOptions?.["vertex"];
+    if (!vertex || typeof vertex !== "object") return params;
+
+    const reasoning = vertex["reasoning"] as ChatCompletionsReasoningConfig | undefined;
+    if (!reasoning) return params;
+
+    // Normalization drops `enabled: true` when no effort/budget is set,
+    // so treat any reasoning object without an explicit disable as enabled.
+    vertex["chat_template_kwargs"] = { enable_thinking: reasoning.enabled !== false };
+    delete vertex["reasoning"];
+    delete vertex["reasoningEffort"];
+
+    return params;
+  },
+};
+
+modelMiddlewareMatcher.useForProvider(["vertex.maas.*"], {
+  language: [vertexGemmaThinkingMiddleware],
 });

--- a/test/e2e/chat-completions/chat-completions-gemma.test.ts
+++ b/test/e2e/chat-completions/chat-completions-gemma.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import OpenAI from "openai";
+
+import { gemma426bA4b } from "../../../src/models/google";
+import { GOOGLE_VERTEX_PROJECT } from "../shared/server";
+import { createVertexTestServer, type TestServer } from "../shared/server";
+
+// ---------------------------------------------------------------------------
+// Environment
+// ---------------------------------------------------------------------------
+
+// Vertex MaaS requires OAuth (ADC / service account); express API keys are
+// rejected by the endpoint. Requires `gcloud auth application-default login`
+// or GOOGLE_APPLICATION_CREDENTIALS in addition to GOOGLE_VERTEX_PROJECT.
+const hasVertexCredentials = !!GOOGLE_VERTEX_PROJECT;
+const VERTEX_MODEL = "google/gemma-4-26b-a4b";
+
+// ---------------------------------------------------------------------------
+// Gateway + Server setup
+// ---------------------------------------------------------------------------
+
+let testServer: TestServer;
+let client: OpenAI;
+let baseUrl: string;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!hasVertexCredentials)(
+  "Chat Completions E2E (Vertex MaaS - Gemma 4 26B-A4B)",
+  () => {
+    beforeAll(() => {
+      testServer = createVertexTestServer(gemma426bA4b());
+      baseUrl = testServer.baseUrl;
+      client = new OpenAI({
+        apiKey: "not-needed",
+        baseURL: `${baseUrl}/v1`,
+      });
+    });
+
+    afterAll(async () => {
+      await testServer?.server?.stop(true);
+    });
+
+    // =========================================================================
+    // reasoning enabled: thinking returned separately from content
+    // =========================================================================
+    test(
+      "reasoning enabled: returns reasoning separated from content",
+      async () => {
+        const completion = (await client.chat.completions.create({
+          model: VERTEX_MODEL,
+          max_completion_tokens: 2048,
+          messages: [{ role: "user", content: "What is 17 * 23? Answer briefly." }],
+          // @ts-expect-error — gateway extension
+          reasoning: { enabled: true },
+        })) as OpenAI.Chat.Completions.ChatCompletion & {
+          choices: { message: { reasoning?: string } }[];
+        };
+
+        const message = completion.choices[0]!.message;
+        expect(message.reasoning).toBeString();
+        expect(message.reasoning!.length).toBeGreaterThan(0);
+        expect(message.content!.replaceAll(",", "")).toContain("391");
+      },
+      { timeout: 120_000 },
+    );
+
+    // =========================================================================
+    // streaming: reasoning deltas separate from content deltas
+    // =========================================================================
+    test(
+      "streaming reasoning: reasoning deltas are separate from content deltas",
+      async () => {
+        const stream = await client.chat.completions.create({
+          model: VERTEX_MODEL,
+          max_completion_tokens: 2048,
+          stream: true,
+          reasoning_effort: "high",
+          messages: [{ role: "user", content: "What is 15 * 37? Answer briefly." }],
+        });
+
+        let content = "";
+        let reasoning = "";
+        for await (const chunk of stream) {
+          const delta = chunk.choices[0]?.delta as
+            | (OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta & { reasoning?: string })
+            | undefined;
+          if (delta?.content) content += delta.content;
+          if (delta?.reasoning) reasoning += delta.reasoning;
+        }
+
+        expect(reasoning.length).toBeGreaterThan(0);
+        expect(content.replaceAll(",", "")).toContain("555");
+      },
+      { timeout: 120_000 },
+    );
+
+    // =========================================================================
+    // reasoning disabled: no thinking tokens generated
+    // =========================================================================
+    test(
+      "reasoning disabled: no reasoning in the response",
+      async () => {
+        const completion = (await client.chat.completions.create({
+          model: VERTEX_MODEL,
+          max_completion_tokens: 256,
+          reasoning_effort:
+            "none" as OpenAI.Chat.Completions.ChatCompletionCreateParams["reasoning_effort"],
+          messages: [{ role: "user", content: "What is 2 + 2?" }],
+        })) as OpenAI.Chat.Completions.ChatCompletion & {
+          choices: { message: { reasoning?: string } }[];
+        };
+
+        const message = completion.choices[0]!.message;
+        expect(message.reasoning).toBeUndefined();
+        expect(message.content).toContain("4");
+      },
+      { timeout: 60_000 },
+    );
+  },
+);

--- a/test/e2e/shared/server.ts
+++ b/test/e2e/shared/server.ts
@@ -1,6 +1,5 @@
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
 import { createVertex } from "@ai-sdk/google-vertex";
-import { createVertexMaas } from "@ai-sdk/google-vertex/maas";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 
 import { type ModelCatalog, defineModelCatalog, gateway } from "../../../src";
@@ -87,18 +86,11 @@ export function createVertexTestServer(...presets: ModelCatalogInput[]): TestSer
     location: GOOGLE_VERTEX_LOCATION,
   });
 
-  // MaaS only accepts OAuth (ADC / service account) and serves Gemma from
-  // the global endpoint; express API keys are rejected by the endpoint itself.
-  const maas = createVertexMaas({
-    project: GOOGLE_VERTEX_PROJECT!,
-    location: "global",
-  });
-
   const gw = gateway({
     basePath: "/v1",
     logger: { level: "warn" },
     providers: {
-      vertex: withCanonicalIdsForVertex(vertex, undefined, maas),
+      vertex: withCanonicalIdsForVertex(vertex),
     },
     models: defineModelCatalog(...presets),
     advanced: { timeouts: { normal: 120_000, flex: 360_000 } },

--- a/test/e2e/shared/server.ts
+++ b/test/e2e/shared/server.ts
@@ -1,5 +1,6 @@
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
 import { createVertex } from "@ai-sdk/google-vertex";
+import { createVertexMaas } from "@ai-sdk/google-vertex/maas";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 
 import { type ModelCatalog, defineModelCatalog, gateway } from "../../../src";
@@ -86,11 +87,18 @@ export function createVertexTestServer(...presets: ModelCatalogInput[]): TestSer
     location: GOOGLE_VERTEX_LOCATION,
   });
 
+  // MaaS only accepts OAuth (ADC / service account) and serves Gemma from
+  // the global endpoint; express API keys are rejected by the endpoint itself.
+  const maas = createVertexMaas({
+    project: GOOGLE_VERTEX_PROJECT!,
+    location: "global",
+  });
+
   const gw = gateway({
     basePath: "/v1",
     logger: { level: "warn" },
     providers: {
-      vertex: withCanonicalIdsForVertex(vertex),
+      vertex: withCanonicalIdsForVertex(vertex, undefined, maas),
     },
     models: defineModelCatalog(...presets),
     advanced: { timeouts: { normal: 120_000, flex: 360_000 } },


### PR DESCRIPTION
Closes #229

- Routes `google/gemma-4-26b-a4b` through Vertex's OpenAI-compatible MaaS endpoint (`@ai-sdk/google-vertex/maas`) when a MaaS provider is passed to `withCanonicalIdsForVertex`; without it, behavior is unchanged.
- New `vertexGemmaThinkingMiddleware` maps the normalized `reasoning` config to Gemma's binary `chat_template_kwargs.enable_thinking` (Gemma-only; other MaaS models control thinking differently).
- Adds `reasoning` to the model's catalog capabilities; unit + e2e tests (e2e verified against live Vertex — MaaS requires OAuth/ADC, express API keys are rejected by the endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reasoning support for Gemma 4 26B A4B on Google Vertex AI MaaS, including proper enable/disable behavior.
  * Added streaming reasoning support, with reasoning emitted alongside response content.
* **Bug Fixes**
  * Automatically routes Gemma 4 26B A4B to the correct Vertex AI MaaS model ID/provider while preserving standard routing for other models.
* **Tests**
  * Added unit coverage for canonical routing and Gemma “thinking” option transformation.
  * Added e2e Vertex MaaS chat-completions tests for enabled, streaming, and disabled reasoning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->