### PR TITLE
feat: support Claude Opus 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Out-of-the-box model presets:
   Nova: `nova` (`v1`, `v2`, `v1.x`, `v2.x`, `latest`, `embeddings`, `all`)
 
 - **Anthropic** — `@hebo-ai/gateway/models/anthropic`  
-  Claude: `claude` (`v4.8`, `v4.7`, `v4.6`, `v4.5`, `v4.1`, `v4`, `v3.7`, `v3.5`, `v3`, `v4.x`, `v3.x`, `fable`, `haiku`, `sonnet`, `opus`, `latest`, `all`)
+  Claude: `claude` (`v5`, `v4.8`, `v4.7`, `v4.6`, `v4.5`, `v4.1`, `v4`, `v3.7`, `v3.5`, `v3`, `v5.x`, `v4.x`, `v3.x`, `fable`, `haiku`, `sonnet`, `opus`, `latest`, `all`)
 
 - **Cohere** — `@hebo-ai/gateway/models/cohere`  
   Command: `command` (`A`, `R`, `latest`, `all`)

--- a/src/models/anthropic/middleware.test.ts
+++ b/src/models/anthropic/middleware.test.ts
@@ -8,6 +8,8 @@ import { claudePromptCachingMiddleware, claudeReasoningMiddleware } from "./midd
 
 test("claudeReasoningMiddleware > matching patterns", () => {
   const matching = [
+    "anthropic/claude-opus-5",
+    "anthropic/claude-opus-4.8",
     "anthropic/claude-opus-4.7",
     "anthropic/claude-opus-4.6",
     "anthropic/claude-sonnet-4.6",
@@ -375,6 +377,74 @@ test("claudeReasoningMiddleware > should map xhigh effort to max for Claude Opus
       unknown: {},
     },
   });
+});
+
+test("claudeReasoningMiddleware > should map xhigh effort to native xhigh for Claude Opus 5", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: {
+          enabled: true,
+          effort: "xhigh",
+        },
+      },
+    },
+  };
+
+  const result = await claudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-5" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "xhigh",
+      },
+      unknown: {},
+    },
+  });
+});
+
+test("claudeReasoningMiddleware > should use adaptive thinking without budget for Claude Opus 5", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: {
+          enabled: true,
+          effort: "medium",
+          max_tokens: 200000,
+        },
+      },
+    },
+  };
+
+  const result = await claudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-5" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "medium",
+      },
+      unknown: {},
+    },
+  });
+  expect(result.providerOptions!["anthropic"]!["thinking"]).not.toHaveProperty("budgetTokens");
 });
 
 test("claudeReasoningMiddleware > should map xhigh effort to native xhigh for Claude Opus 4.7", async () => {

--- a/src/models/anthropic/middleware.test.ts
+++ b/src/models/anthropic/middleware.test.ts
@@ -9,6 +9,7 @@ import { claudePromptCachingMiddleware, claudeReasoningMiddleware } from "./midd
 test("claudeReasoningMiddleware > matching patterns", () => {
   const matching = [
     "anthropic/claude-opus-5",
+    "anthropic/claude-sonnet-5",
     "anthropic/claude-opus-4.8",
     "anthropic/claude-opus-4.7",
     "anthropic/claude-opus-4.6",
@@ -430,6 +431,74 @@ test("claudeReasoningMiddleware > should use adaptive thinking without budget fo
     type: "generate",
     params,
     model: new MockLanguageModelV3({ modelId: "anthropic/claude-opus-5" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "medium",
+      },
+      unknown: {},
+    },
+  });
+  expect(result.providerOptions!["anthropic"]!["thinking"]).not.toHaveProperty("budgetTokens");
+});
+
+test("claudeReasoningMiddleware > should map xhigh effort to native xhigh for Claude Sonnet 5", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: {
+          enabled: true,
+          effort: "xhigh",
+        },
+      },
+    },
+  };
+
+  const result = await claudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-sonnet-5" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          type: "adaptive",
+        },
+        effort: "xhigh",
+      },
+      unknown: {},
+    },
+  });
+});
+
+test("claudeReasoningMiddleware > should use adaptive thinking without budget for Claude Sonnet 5", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: {
+          enabled: true,
+          effort: "medium",
+          max_tokens: 200000,
+        },
+      },
+    },
+  };
+
+  const result = await claudeReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV3({ modelId: "anthropic/claude-sonnet-5" }),
   });
 
   expect(result).toEqual({

--- a/src/models/anthropic/middleware.ts
+++ b/src/models/anthropic/middleware.ts
@@ -19,8 +19,9 @@ const isClaude = (family: "opus" | "sonnet" | "haiku", version: string) => {
 const isClaude4 = (modelId: string) => modelId.includes("claude-") && modelId.includes("-4");
 const isFable5 = (modelId: string) => modelId.includes("claude-fable-5");
 const isOpus5 = (modelId: string) => modelId.includes("claude-opus-5");
+const isSonnet5 = (modelId: string) => modelId.includes("claude-sonnet-5");
 const isClaude4OrFable = (modelId: string) =>
-  isClaude4(modelId) || isFable5(modelId) || isOpus5(modelId);
+  isClaude4(modelId) || isFable5(modelId) || isOpus5(modelId) || isSonnet5(modelId);
 
 const isOpus48 = isClaude("opus", "4.8");
 const isOpus47 = isClaude("opus", "4.7");
@@ -29,11 +30,19 @@ const isOpus45 = isClaude("opus", "4.5");
 const isOpus4 = isClaude("opus", "4");
 const isSonnet46 = isClaude("sonnet", "4.6");
 
+// Models with native effort levels (low–max) and adaptive extended thinking.
+const isNativeEffortClaude = (modelId: string) =>
+  isOpus5(modelId) ||
+  isSonnet5(modelId) ||
+  isFable5(modelId) ||
+  isOpus48(modelId) ||
+  isOpus47(modelId);
+
 export function mapClaudeReasoningEffort(
   effort: ChatCompletionsReasoningEffort,
   modelId: string,
 ): "low" | "medium" | "high" | "xhigh" | "max" | undefined {
-  if (isOpus5(modelId) || isOpus48(modelId) || isOpus47(modelId) || isFable5(modelId)) {
+  if (isNativeEffortClaude(modelId)) {
     switch (effort) {
       case "none":
       case "minimal":
@@ -83,11 +92,7 @@ export function mapClaudeReasoningEffort(
 }
 
 function getMaxOutputTokens(modelId: string): number {
-  if (isOpus5(modelId)) return 128_000;
-  if (isOpus48(modelId)) return 128_000;
-  if (isFable5(modelId)) return 128_000;
-  if (isOpus47(modelId)) return 128_000;
-  if (isOpus46(modelId)) return 128_000;
+  if (isNativeEffortClaude(modelId) || isOpus46(modelId)) return 128_000;
   if (isOpus45(modelId)) return 64_000;
   if (isOpus4(modelId)) return 32_000;
   return 64_000;
@@ -118,7 +123,7 @@ export const claudeReasoningMiddleware: LanguageModelMiddleware = {
       if (isClaude4OrFable(modelId)) {
         target.effort = mapClaudeReasoningEffort(reasoning.effort, modelId);
       }
-      if (isOpus5(modelId) || isOpus48(modelId) || isOpus47(modelId) || isFable5(modelId)) {
+      if (isNativeEffortClaude(modelId)) {
         target.thinking = { type: "adaptive" };
       } else if (isOpus46(modelId)) {
         target.thinking = clampedMaxTokens
@@ -189,6 +194,7 @@ modelMiddlewareMatcher.useForModel(
     "anthropic/claude-*3*7*",
     "anthropic/claude-*4*",
     "anthropic/claude-opus-5*",
+    "anthropic/claude-sonnet-5*",
     "anthropic/claude-fable-*",
   ],
   {

--- a/src/models/anthropic/middleware.ts
+++ b/src/models/anthropic/middleware.ts
@@ -18,7 +18,9 @@ const isClaude = (family: "opus" | "sonnet" | "haiku", version: string) => {
 
 const isClaude4 = (modelId: string) => modelId.includes("claude-") && modelId.includes("-4");
 const isFable5 = (modelId: string) => modelId.includes("claude-fable-5");
-const isClaude4OrFable = (modelId: string) => isClaude4(modelId) || isFable5(modelId);
+const isOpus5 = (modelId: string) => modelId.includes("claude-opus-5");
+const isClaude4OrFable = (modelId: string) =>
+  isClaude4(modelId) || isFable5(modelId) || isOpus5(modelId);
 
 const isOpus48 = isClaude("opus", "4.8");
 const isOpus47 = isClaude("opus", "4.7");
@@ -31,7 +33,7 @@ export function mapClaudeReasoningEffort(
   effort: ChatCompletionsReasoningEffort,
   modelId: string,
 ): "low" | "medium" | "high" | "xhigh" | "max" | undefined {
-  if (isOpus48(modelId) || isOpus47(modelId) || isFable5(modelId)) {
+  if (isOpus5(modelId) || isOpus48(modelId) || isOpus47(modelId) || isFable5(modelId)) {
     switch (effort) {
       case "none":
       case "minimal":
@@ -81,6 +83,7 @@ export function mapClaudeReasoningEffort(
 }
 
 function getMaxOutputTokens(modelId: string): number {
+  if (isOpus5(modelId)) return 128_000;
   if (isOpus48(modelId)) return 128_000;
   if (isFable5(modelId)) return 128_000;
   if (isOpus47(modelId)) return 128_000;
@@ -115,7 +118,7 @@ export const claudeReasoningMiddleware: LanguageModelMiddleware = {
       if (isClaude4OrFable(modelId)) {
         target.effort = mapClaudeReasoningEffort(reasoning.effort, modelId);
       }
-      if (isOpus48(modelId) || isOpus47(modelId) || isFable5(modelId)) {
+      if (isOpus5(modelId) || isOpus48(modelId) || isOpus47(modelId) || isFable5(modelId)) {
         target.thinking = { type: "adaptive" };
       } else if (isOpus46(modelId)) {
         target.thinking = clampedMaxTokens
@@ -182,7 +185,12 @@ export const claudePromptCachingMiddleware: LanguageModelMiddleware = {
 };
 
 modelMiddlewareMatcher.useForModel(
-  ["anthropic/claude-*3*7*", "anthropic/claude-*4*", "anthropic/claude-fable-*"],
+  [
+    "anthropic/claude-*3*7*",
+    "anthropic/claude-*4*",
+    "anthropic/claude-opus-5*",
+    "anthropic/claude-fable-*",
+  ],
   {
     language: [claudeReasoningMiddleware, claudePromptCachingMiddleware],
   },

--- a/src/models/anthropic/presets.ts
+++ b/src/models/anthropic/presets.ts
@@ -128,6 +128,19 @@ export const claudeOpus45 = presetFor<CanonicalModelId, CatalogModel>()(
   } satisfies DeepPartial<CatalogModel>,
 );
 
+export const claudeOpus5 = presetFor<CanonicalModelId, CatalogModel>()(
+  "anthropic/claude-opus-5" as const,
+  {
+    ...CLAUDE_BASE,
+    ...CLAUDE_PDF_MODALITIES,
+    name: "Claude Opus 5",
+    capabilities: [...CLAUDE_BASE.capabilities, "reasoning"],
+    context: 1_000_000,
+    created: "2026-07-24",
+    knowledge: "2026-05",
+  } satisfies DeepPartial<CatalogModel>,
+);
+
 export const claudeOpus48 = presetFor<CanonicalModelId, CatalogModel>()(
   "anthropic/claude-opus-4.8" as const,
   {
@@ -204,6 +217,7 @@ export const claudeOpus4 = presetFor<CanonicalModelId, CatalogModel>()(
 );
 
 const claudeAtomic = {
+  v5: [claudeOpus5],
   "v4.8": [claudeOpus48],
   "v4.7": [claudeOpus47],
   "v4.6": [claudeSonnet46, claudeOpus46],
@@ -216,10 +230,19 @@ const claudeAtomic = {
   fable: [claudeFable5],
   haiku: [claudeHaiku45, claudeHaiku35, claudeHaiku3],
   sonnet: [claudeSonnet46, claudeSonnet45, claudeSonnet4, claudeSonnet37, claudeSonnet35],
-  opus: [claudeOpus48, claudeOpus47, claudeOpus46, claudeOpus45, claudeOpus41, claudeOpus4],
+  opus: [
+    claudeOpus5,
+    claudeOpus48,
+    claudeOpus47,
+    claudeOpus46,
+    claudeOpus45,
+    claudeOpus41,
+    claudeOpus4,
+  ],
 } as const;
 
 const claudeGroups = {
+  "v5.x": [...claudeAtomic["v5"]],
   "v4.x": [
     ...claudeAtomic["v4.8"],
     ...claudeAtomic["v4.7"],
@@ -234,6 +257,6 @@ const claudeGroups = {
 export const claude = {
   ...claudeAtomic,
   ...claudeGroups,
-  latest: [...claudeAtomic["v4.8"], ...claudeAtomic["fable"]],
+  latest: [...claudeAtomic["v5"], ...claudeAtomic["fable"]],
   all: Object.values(claudeAtomic).flat(),
 } as const;

--- a/src/models/anthropic/presets.ts
+++ b/src/models/anthropic/presets.ts
@@ -69,6 +69,19 @@ export const claudeSonnet45 = presetFor<CanonicalModelId, CatalogModel>()(
   } satisfies DeepPartial<CatalogModel>,
 );
 
+export const claudeSonnet5 = presetFor<CanonicalModelId, CatalogModel>()(
+  "anthropic/claude-sonnet-5" as const,
+  {
+    ...CLAUDE_BASE,
+    ...CLAUDE_PDF_MODALITIES,
+    name: "Claude Sonnet 5",
+    capabilities: [...CLAUDE_BASE.capabilities, "reasoning"],
+    context: 1_000_000,
+    created: "2026-06-29",
+    knowledge: "2026-01",
+  } satisfies DeepPartial<CatalogModel>,
+);
+
 export const claudeSonnet46 = presetFor<CanonicalModelId, CatalogModel>()(
   "anthropic/claude-sonnet-4.6" as const,
   {
@@ -217,7 +230,7 @@ export const claudeOpus4 = presetFor<CanonicalModelId, CatalogModel>()(
 );
 
 const claudeAtomic = {
-  v5: [claudeOpus5],
+  v5: [claudeOpus5, claudeSonnet5, claudeFable5],
   "v4.8": [claudeOpus48],
   "v4.7": [claudeOpus47],
   "v4.6": [claudeSonnet46, claudeOpus46],
@@ -229,7 +242,14 @@ const claudeAtomic = {
   v3: [claudeHaiku3],
   fable: [claudeFable5],
   haiku: [claudeHaiku45, claudeHaiku35, claudeHaiku3],
-  sonnet: [claudeSonnet46, claudeSonnet45, claudeSonnet4, claudeSonnet37, claudeSonnet35],
+  sonnet: [
+    claudeSonnet5,
+    claudeSonnet46,
+    claudeSonnet45,
+    claudeSonnet4,
+    claudeSonnet37,
+    claudeSonnet35,
+  ],
   opus: [
     claudeOpus5,
     claudeOpus48,
@@ -257,6 +277,6 @@ const claudeGroups = {
 export const claude = {
   ...claudeAtomic,
   ...claudeGroups,
-  latest: [...claudeAtomic["v5"], ...claudeAtomic["fable"]],
+  latest: [...claudeAtomic["v5"]],
   all: Object.values(claudeAtomic).flat(),
 } as const;

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -2,6 +2,7 @@ import type { ProviderId } from "../providers/types";
 
 export const CANONICAL_MODEL_IDS = [
   // Anthropic
+  "anthropic/claude-opus-5",
   "anthropic/claude-fable-5",
   "anthropic/claude-opus-4.8",
   "anthropic/claude-opus-4.7",

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -3,6 +3,7 @@ import type { ProviderId } from "../providers/types";
 export const CANONICAL_MODEL_IDS = [
   // Anthropic
   "anthropic/claude-opus-5",
+  "anthropic/claude-sonnet-5",
   "anthropic/claude-fable-5",
   "anthropic/claude-opus-4.8",
   "anthropic/claude-opus-4.7",

--- a/src/providers/bedrock/canonical.test.ts
+++ b/src/providers/bedrock/canonical.test.ts
@@ -9,3 +9,9 @@ test("withCanonicalIdsForBedrock > maps Claude Opus 5 to inference profile witho
   const model = provider.languageModel("anthropic/claude-opus-5");
   expect(model.modelId).toBe("us.anthropic.claude-opus-5");
 });
+
+test("withCanonicalIdsForBedrock > maps Claude Sonnet 5 to inference profile without version postfix", () => {
+  const provider = withCanonicalIdsForBedrock(createAmazonBedrock({ region: "us-east-1" }));
+  const model = provider.languageModel("anthropic/claude-sonnet-5");
+  expect(model.modelId).toBe("us.anthropic.claude-sonnet-5");
+});

--- a/src/providers/bedrock/canonical.test.ts
+++ b/src/providers/bedrock/canonical.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+
+import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
+
+import { withCanonicalIdsForBedrock } from "./canonical";
+
+test("withCanonicalIdsForBedrock > maps Claude Opus 5 to inference profile without version postfix", () => {
+  const provider = withCanonicalIdsForBedrock(createAmazonBedrock({ region: "us-east-1" }));
+  const model = provider.languageModel("anthropic/claude-opus-5");
+  expect(model.modelId).toBe("us.anthropic.claude-opus-5");
+});

--- a/src/providers/bedrock/canonical.ts
+++ b/src/providers/bedrock/canonical.ts
@@ -11,6 +11,7 @@ import { withCanonicalIds } from "../registry";
 //     --output table
 const MAPPING = {
   // Require Inference Profiles and can't be resolved from standard name mapping
+  "anthropic/claude-opus-5": "{ip}anthropic.claude-opus-5",
   "anthropic/claude-haiku-4.5": "{ip}anthropic.claude-haiku-4-5-20251001-v1:0",
   "anthropic/claude-fable-5": "{ip}anthropic.claude-fable-5",
   "anthropic/claude-opus-4.8": "{ip}anthropic.claude-opus-4-8",

--- a/src/providers/bedrock/canonical.ts
+++ b/src/providers/bedrock/canonical.ts
@@ -12,6 +12,7 @@ import { withCanonicalIds } from "../registry";
 const MAPPING = {
   // Require Inference Profiles and can't be resolved from standard name mapping
   "anthropic/claude-opus-5": "{ip}anthropic.claude-opus-5",
+  "anthropic/claude-sonnet-5": "{ip}anthropic.claude-sonnet-5",
   "anthropic/claude-haiku-4.5": "{ip}anthropic.claude-haiku-4-5-20251001-v1:0",
   "anthropic/claude-fable-5": "{ip}anthropic.claude-fable-5",
   "anthropic/claude-opus-4.8": "{ip}anthropic.claude-opus-4-8",


### PR DESCRIPTION
Adds support for Claude Opus 5 (`anthropic/claude-opus-5`): canonical ID, preset (1M context, reasoning, PDF, 128k max output), grouped exports (`v5`/`v5.x`, new `latest`), Bedrock inference-profile mapping, and reasoning/adaptive-thinking middleware wiring.

Resolves #233

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Anthropic Claude Opus 5 and Sonnet 5, including preset catalog and the latest Claude grouping.
  - Expanded model matching so v5 variants are recognized for reasoning and prompt caching behavior.
  - Added Amazon Bedrock canonicalization for Claude Opus 5 and Sonnet 5 identifiers.
  - Enhanced adaptive reasoning for native-effort Claude v5 models with `xhigh`, including increased token capacity.

- **Documentation**
  - Updated model presets documentation to include Claude v5 and v5.x identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->