### PR TITLE
fix(vertex): honor provider project and credentials in MaaS override

### DIFF
--- a/src/providers/vertex/canonical.test.ts
+++ b/src/providers/vertex/canonical.test.ts
@@ -25,3 +25,80 @@ test("other models fall back to the native provider", () => {
   expect(model.modelId).toBe("gemini-3-flash-preview");
   expect(model.provider).toBe("google.vertex.chat");
 });
+
+// ---------------------------------------------------------------------------
+// The MaaS override inherits the provider's project and credentials
+// ---------------------------------------------------------------------------
+
+/** Stubs google-auth-library so no ambient credentials are ever consulted. */
+const authClientFor = (token: string) =>
+  ({
+    authClient: { getAccessToken: () => Promise.resolve({ token }) },
+  }) as unknown as NonNullable<Parameters<typeof createVertex>[0]>["googleAuthOptions"];
+
+/** Captures the request the MaaS model would send, without hitting the network. */
+async function captureMaasRequest(
+  settings: Omit<Parameters<typeof createVertex>[0], "fetch"> = {},
+): Promise<{ url: string; headers: Headers }> {
+  let captured: { url: string; headers: Headers } | undefined;
+
+  const provider = withCanonicalIdsForVertex(
+    createVertex({
+      googleAuthOptions: authClientFor("configured-token"),
+      ...settings,
+      fetch: ((input: RequestInfo | URL, init?: RequestInit) => {
+        captured = {
+          url: input instanceof Request ? input.url : String(input),
+          headers: new Headers(init?.headers),
+        };
+        throw new Error("captured");
+      }) as unknown as typeof fetch,
+    }),
+  );
+
+  // The capturing fetch always throws, so only the request itself is asserted on.
+  try {
+    await provider
+      .languageModel("google/gemma-4-26b-a4b")
+      .doGenerate({ prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }] });
+  } catch {
+    // expected
+  }
+
+  return captured!;
+}
+
+test("MaaS override uses the provider's project instead of GOOGLE_VERTEX_PROJECT", async () => {
+  const { url } = await captureMaasRequest({ project: "my-project", location: "us-central1" });
+
+  expect(url).toContain("/projects/my-project/");
+  expect(url).not.toContain("test-project");
+  // Gemma is only served from the global MaaS endpoint.
+  expect(url).toContain("/locations/global/");
+});
+
+test("MaaS override authenticates with the provider's googleAuthOptions", async () => {
+  const { headers } = await captureMaasRequest({
+    project: "my-project",
+    location: "us-central1",
+  });
+
+  expect(headers.get("authorization")).toBe("Bearer configured-token");
+});
+
+test("MaaS override forwards the provider's custom headers", async () => {
+  const { headers } = await captureMaasRequest({
+    project: "my-project",
+    location: "us-central1",
+    headers: { "x-custom": "yes" },
+  });
+
+  expect(headers.get("x-custom")).toBe("yes");
+  expect(headers.get("authorization")).toBe("Bearer configured-token");
+});
+
+test("MaaS override falls back to GOOGLE_VERTEX_PROJECT when no project is configured", async () => {
+  const { url } = await captureMaasRequest({ location: "us-central1" });
+
+  expect(url).toContain("/projects/test-project/");
+});

--- a/src/providers/vertex/canonical.ts
+++ b/src/providers/vertex/canonical.ts
@@ -1,5 +1,9 @@
 import type { GoogleVertexProvider } from "@ai-sdk/google-vertex";
-import { createVertexMaas } from "@ai-sdk/google-vertex/maas";
+import {
+  createVertexMaas,
+  type GoogleVertexMaasProvider,
+  type GoogleVertexMaasProviderSettings,
+} from "@ai-sdk/google-vertex/maas";
 import { customProvider } from "ai";
 
 import type { CanonicalModelId, ModelId } from "../../models/types";
@@ -10,13 +14,64 @@ const MAPPING = {
   "deepseek/deepseek-v3.2": "deepseek-v3.2-maas",
 } as const satisfies Partial<Record<CanonicalModelId, string>>;
 
+/**
+ * `createVertex` keeps `project` and `googleAuthOptions` in a closure, so the resolved
+ * base URL, auth headers, and fetch are only reachable through the config the AI SDK
+ * attaches to a model instance.
+ */
+type VertexModelConfig = {
+  baseURL?: string;
+  headers?: GoogleVertexMaasProviderSettings["headers"];
+  fetch?: GoogleVertexMaasProviderSettings["fetch"];
+};
+
+// Gemma thinking is not exposed via generateContent, so it routes through the
+// MaaS endpoint, which serves Gemma only from the global endpoint.
+const createMaas = (provider: GoogleVertexProvider): GoogleVertexMaasProvider => {
+  // Any model id works: constructing a model issues no request, it only resolves settings.
+  const { config } = provider.languageModel("gemini-2.5-flash") as unknown as {
+    config: VertexModelConfig;
+  };
+
+  // Express mode (API key) resolves no project into its base URL, and MaaS rejects API
+  // keys anyway, so that path keeps the MaaS defaults (env vars + ADC).
+  const project = config.baseURL?.split("/projects/")[1]?.split("/")[0];
+  if (!project) return createVertexMaas({ location: "global" });
+
+  // Resolved per request: the bearer token expires. Keys are lower-cased by the SDK.
+  const resolveVertexHeaders = async () => {
+    const { headers } = config;
+    return (typeof headers === "function" ? await headers() : await headers) ?? {};
+  };
+
+  return createVertexMaas({
+    project,
+    location: "global",
+    fetch: config.fetch,
+    // MaaS appends its own capitalized `Authorization`, so leaving the lower-cased one
+    // in would send both tokens comma-joined in a single header.
+    headers: async () => {
+      const { authorization: _dropped, ...rest } = await resolveVertexHeaders();
+      return rest;
+    },
+    // MaaS mints its own token, defaulting to ambient credentials. Handing it the token
+    // the native provider already resolved keeps both on the configured credentials.
+    googleAuthOptions: {
+      authClient: {
+        getAccessToken: async () => ({
+          token: (await resolveVertexHeaders())["authorization"]?.slice("Bearer ".length) ?? null,
+        }),
+      },
+    } as unknown as GoogleVertexMaasProviderSettings["googleAuthOptions"],
+  });
+};
+
 export const withCanonicalIdsForVertex = (
   provider: GoogleVertexProvider,
   extraMapping?: Record<ModelId, string>,
 ) => {
-  // Gemma thinking is not exposed via generateContent, so it routes through the
-  // MaaS endpoint, which serves Gemma only from the global endpoint.
-  const maas = createVertexMaas({ location: "global" });
+  // Deferred so incomplete settings surface at model construction, not at wrap time.
+  let maas: GoogleVertexMaasProvider | undefined;
 
   const base = withCanonicalIds(provider, {
     mapping: { ...MAPPING, ...extraMapping },
@@ -29,6 +84,7 @@ export const withCanonicalIdsForVertex = (
   return customProvider({
     languageModels: {
       get "google/gemma-4-26b-a4b"() {
+        maas ??= createMaas(provider);
         return maas.languageModel("google/gemma-4-26b-a4b-it-maas");
       },
     },


### PR DESCRIPTION
## Summary

`withCanonicalIdsForVertex` built its MaaS provider with only `{ location: "global" }`, so the `project` and `googleAuthOptions` passed to `createVertex` were dropped for `google/gemma-4-26b-a4b`. Requests fell back to `GOOGLE_VERTEX_PROJECT` and ambient Application Default Credentials.

## Changes

`createVertex` keeps both settings in a closure and exposes neither on the returned provider, so they are read back off the config the AI SDK attaches to a model instance (constructing a model issues no request):

- **Project** — taken from the resolved base URL and passed to `createVertexMaas`.
- **Auth** — MaaS mints its own bearer token from `googleAuthOptions`, so its auth client is pointed at the token the native provider resolves. Resolved per request, since the token expires.
- **Custom headers** — forwarded via the `headers` option, minus the lower-cased `authorization`: MaaS appends its own capitalized `Authorization`, so leaving it in sends both tokens comma-joined in one header.
- **Lazy construction** — the MaaS provider is created on first model access, so incomplete settings surface at model construction rather than at wrap time.

Express mode (`apiKey`) resolves no project into its base URL, and MaaS rejects API keys anyway, so that path keeps the previous env-var + ADC defaults.

## Tests

Four tests added to `src/providers/vertex/canonical.test.ts` covering project override, credential propagation, custom-header forwarding, and env-var fallback, using a capturing `fetch` so nothing hits the network. All four were confirmed to fail without the fix.

- `bunx oxlint src/providers/vertex/` — clean
- `bun run typecheck` — 34 errors, identical count with the change stashed; none in the touched files
- `bun run test` — 690 pass, 1 fail

The one failure (`middleware.test.ts:150`) is pre-existing on `main` and unrelated to this change.

Fixes #236

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vertex MaaS authentication and project selection.
  * Added support for configured Google authentication options and project fallback settings.
  * Preserved valid bearer credentials while removing conflicting authorization headers.
  * Ensured custom headers and global MaaS routing are forwarded correctly.
  * Deferred MaaS provider setup until a Gemma model is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->