### PR TITLE
fix(google): rename Gemini 3.1 Flash-Lite canonical ID to match Vertex

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Out-of-the-box model presets:
   DeepSeek: `deepseek` (`v3.2`, `v4`, `v4.x`, `latest`, `all`)
 
 - **Google** — `@hebo-ai/gateway/models/google`  
-  Gemini: `gemini` (`v2.5`, `v3.5`, `v3.6`, `v3-preview`, `v2.x`, `v3.x`, `embeddings`, `latest`, `preview`, `all`)
+  Gemini: `gemini` (`v2.5`, `v3.1`, `v3.5`, `v3.6`, `v3-preview`, `v2.x`, `v3.x`, `embeddings`, `latest`, `preview`, `all`)
   Gemma: `gemma` (`v3`, `v4`, `v3.x`, `v4.x`, `latest`, `all`)
 
 - **Meta** — `@hebo-ai/gateway/models/meta`  

--- a/src/models/google/middleware.test.ts
+++ b/src/models/google/middleware.test.ts
@@ -17,7 +17,7 @@ test("geminiReasoningMiddleware > matching patterns", () => {
     "google/gemini-2.5-flash",
     "google/gemini-2.5-pro",
     "google/gemini-3-flash-preview",
-    "google/gemini-3.1-flash-lite-preview",
+    "google/gemini-3.1-flash-lite",
     "google/gemini-3.1-pro-preview",
   ] satisfies (typeof CANONICAL_MODEL_IDS)[number][];
 
@@ -151,7 +151,7 @@ test("geminiReasoningMiddleware > should normalize none effort for Gemini 3.1 Fl
   const result = await geminiReasoningMiddleware.transformParams!({
     type: "generate",
     params,
-    model: new MockLanguageModelV4({ modelId: "google/gemini-3.1-flash-lite-preview" }),
+    model: new MockLanguageModelV4({ modelId: "google/gemini-3.1-flash-lite" }),
   });
 
   expect(result).toEqual({

--- a/src/models/google/presets.ts
+++ b/src/models/google/presets.ts
@@ -67,11 +67,11 @@ export const gemini3FlashPreview = presetFor<CanonicalModelId, CatalogModel>()(
   } satisfies DeepPartial<CatalogModel>,
 );
 
-export const gemini31FlashLitePreview = presetFor<CanonicalModelId, CatalogModel>()(
-  "google/gemini-3.1-flash-lite-preview" as const,
+export const gemini31FlashLite = presetFor<CanonicalModelId, CatalogModel>()(
+  "google/gemini-3.1-flash-lite" as const,
   {
     ...GEMINI_3X_BASE,
-    name: "Gemini 3.1 Flash-Lite (Preview)",
+    name: "Gemini 3.1 Flash-Lite",
     created: "2026-03-03",
     knowledge: "2025-01",
   } satisfies DeepPartial<CatalogModel>,
@@ -285,15 +285,21 @@ export const gemma = {
 
 const geminiAtomic = {
   "v2.5": [gemini25FlashLite, gemini25Flash, gemini25Pro],
+  "v3.1": [gemini31FlashLite],
   "v3.5": [gemini35FlashLite, gemini35Flash],
   "v3.6": [gemini36Flash],
-  "v3-preview": [gemini3FlashPreview, gemini31FlashLitePreview, gemini31ProPreview],
+  "v3-preview": [gemini3FlashPreview, gemini31ProPreview],
   embeddings: [geminiEmbedding001, geminiEmbedding2],
 } as const;
 
 const geminiGroups = {
   "v2.x": [...geminiAtomic["v2.5"]],
-  "v3.x": [...geminiAtomic["v3-preview"], ...geminiAtomic["v3.5"], ...geminiAtomic["v3.6"]],
+  "v3.x": [
+    ...geminiAtomic["v3-preview"],
+    ...geminiAtomic["v3.1"],
+    ...geminiAtomic["v3.5"],
+    ...geminiAtomic["v3.6"],
+  ],
 } as const;
 
 export const gemini = {

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -59,7 +59,7 @@ export const CANONICAL_MODEL_IDS = [
   "google/gemini-2.5-flash",
   "google/gemini-2.5-pro",
   "google/gemini-3-flash-preview",
-  "google/gemini-3.1-flash-lite-preview",
+  "google/gemini-3.1-flash-lite",
   "google/gemini-3.1-pro-preview",
   "google/gemini-3.5-flash",
   "google/gemini-3.5-flash-lite",


### PR DESCRIPTION
- Canonical ID is now `google/gemini-3.1-flash-lite`, which strips to the ID Vertex actually serves (`gemini-3.1-flash-lite`), so no provider mapping is needed. Preset export renamed to `gemini31FlashLite` and moved from the `v3-preview` group to a new `v3.1` group.
- Fixes #242.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the stable Google Gemini 3.1 Flash-Lite model to the available model presets.
  * Updated the Gemini model list to include version 3.1.

* **Bug Fixes**
  * Replaced the deprecated preview model identifier with the current canonical model name.
  * Updated model grouping and display names to accurately reflect the stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->