### PR TITLE
feat(google): add Gemini 3.7 Flash preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Out-of-the-box model presets:
   DeepSeek: `deepseek` (`v3.2`, `v4`, `v4.x`, `latest`, `all`)
 
 - **Google** — `@hebo-ai/gateway/models/google`  
-  Gemini: `gemini` (`v2.5`, `v3.1`, `v3.5`, `v3.6`, `v3-preview`, `v2.x`, `v3.x`, `embeddings`, `latest`, `preview`, `all`)
+  Gemini: `gemini` (`v2.5`, `v3.1`, `v3.5`, `v3.6`, `v3.7`, `v3-preview`, `v2.x`, `v3.x`, `embeddings`, `latest`, `preview`, `all`)
   Gemma: `gemma` (`v3`, `v4`, `v3.x`, `v4.x`, `latest`, `all`)
 
 - **Meta** — `@hebo-ai/gateway/models/meta`  

--- a/src/models/google/middleware.test.ts
+++ b/src/models/google/middleware.test.ts
@@ -19,6 +19,7 @@ test("geminiReasoningMiddleware > matching patterns", () => {
     "google/gemini-3-flash-preview",
     "google/gemini-3.1-flash-lite",
     "google/gemini-3.1-pro-preview",
+    "google/gemini-3.7-flash",
   ] satisfies (typeof CANONICAL_MODEL_IDS)[number][];
 
   const nonMatching = ["google/gemini-1.5-pro", "google/gemini-1.5-flash"];
@@ -249,6 +250,38 @@ test("geminiReasoningMiddleware > should default reasoning effort for Gemini 3 F
     providerOptions: {
       google: {
         thinkingConfig: {
+          includeThoughts: true,
+        },
+      },
+      unknown: {},
+    },
+  });
+});
+
+// Uses the provider-native id: newer Gemini 3.x minors must hit the same branch
+// without an added pattern, so 3.8+ needs no middleware change.
+test("geminiReasoningMiddleware > should map thinking level for Gemini 3.7 Flash", async () => {
+  const params = {
+    prompt: [],
+    providerOptions: {
+      unknown: {
+        reasoning: { enabled: true, effort: "high" },
+      },
+    },
+  };
+
+  const result = await geminiReasoningMiddleware.transformParams!({
+    type: "generate",
+    params,
+    model: new MockLanguageModelV4({ modelId: "gemini-3.7-flash" }),
+  });
+
+  expect(result).toEqual({
+    prompt: [],
+    providerOptions: {
+      google: {
+        thinkingConfig: {
+          thinkingLevel: "high",
           includeThoughts: true,
         },
       },

--- a/src/models/google/presets.test.ts
+++ b/src/models/google/presets.test.ts
@@ -3,12 +3,30 @@ import { expect, test } from "bun:test";
 import {
   gemini35FlashLite,
   gemini36Flash,
+  gemini37Flash,
   geminiEmbedding2,
   gemma31b,
   gemma4E4b,
   gemma,
   gemini,
 } from "./presets";
+
+test("gemini37Flash > should expose Gemini 3.7 Flash metadata", () => {
+  expect(gemini37Flash()).toEqual({
+    "google/gemini-3.7-flash": {
+      name: "Gemini 3.7 Flash",
+      created: "2026-08-13",
+      knowledge: "2026-03",
+      modalities: {
+        input: ["text", "image", "pdf", "file", "audio", "video"],
+        output: ["text"],
+      },
+      capabilities: ["attachments", "reasoning", "tool_call", "structured_output"],
+      context: 1048576,
+      providers: ["vertex"],
+    },
+  });
+});
 
 test("gemini36Flash > should expose Gemini 3.6 Flash metadata", () => {
   expect(gemini36Flash()).toEqual({
@@ -44,15 +62,16 @@ test("gemini35FlashLite > should expose Gemini 3.5 Flash-Lite metadata", () => {
   });
 });
 
-test("gemini.latest > should point to Gemini 3.6 Flash", () => {
+test("gemini.latest > should point to Gemini 3.7 Flash", () => {
   const ids = gemini.latest.map((preset) => Object.keys(preset())[0]);
-  expect(ids).toEqual(["google/gemini-3.6-flash"]);
+  expect(ids).toEqual(["google/gemini-3.7-flash"]);
 });
 
-test("gemini.v3.x > should include the new 3.5 Flash-Lite and 3.6 Flash models", () => {
+test("gemini.v3.x > should include the new 3.5 Flash-Lite, 3.6 Flash and 3.7 Flash models", () => {
   const ids = gemini["v3.x"].map((preset) => Object.keys(preset())[0]);
   expect(ids).toContain("google/gemini-3.5-flash-lite");
   expect(ids).toContain("google/gemini-3.6-flash");
+  expect(ids).toContain("google/gemini-3.7-flash");
 });
 
 test("geminiEmbedding2 > should expose GA embedding metadata with multimodal input", () => {

--- a/src/models/google/presets.ts
+++ b/src/models/google/presets.ts
@@ -87,6 +87,16 @@ export const gemini31ProPreview = presetFor<CanonicalModelId, CatalogModel>()(
   } satisfies DeepPartial<CatalogModel>,
 );
 
+export const gemini37Flash = presetFor<CanonicalModelId, CatalogModel>()(
+  "google/gemini-3.7-flash" as const,
+  {
+    ...GEMINI_3X_BASE,
+    name: "Gemini 3.7 Flash",
+    created: "2026-08-13",
+    knowledge: "2026-03",
+  } satisfies DeepPartial<CatalogModel>,
+);
+
 export const gemini36Flash = presetFor<CanonicalModelId, CatalogModel>()(
   "google/gemini-3.6-flash" as const,
   {
@@ -288,6 +298,7 @@ const geminiAtomic = {
   "v3.1": [gemini31FlashLite],
   "v3.5": [gemini35FlashLite, gemini35Flash],
   "v3.6": [gemini36Flash],
+  "v3.7": [gemini37Flash],
   "v3-preview": [gemini3FlashPreview, gemini31ProPreview],
   embeddings: [geminiEmbedding001, geminiEmbedding2],
 } as const;
@@ -299,13 +310,14 @@ const geminiGroups = {
     ...geminiAtomic["v3.1"],
     ...geminiAtomic["v3.5"],
     ...geminiAtomic["v3.6"],
+    ...geminiAtomic["v3.7"],
   ],
 } as const;
 
 export const gemini = {
   ...geminiAtomic,
   ...geminiGroups,
-  latest: [...geminiAtomic["v3.6"]],
+  latest: [...geminiAtomic["v3.7"]],
   preview: [...geminiAtomic["v3-preview"]],
   embeddings: [...geminiAtomic["embeddings"]],
   all: Object.values(geminiAtomic).flat(),

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -67,6 +67,7 @@ export const CANONICAL_MODEL_IDS = [
   "google/gemini-3.5-flash",
   "google/gemini-3.5-flash-lite",
   "google/gemini-3.6-flash",
+  "google/gemini-3.7-flash",
   "google/gemini-embedding-2",
   "google/embedding-001",
   "google/gemma-3-1b",

--- a/src/providers/vertex/canonical.test.ts
+++ b/src/providers/vertex/canonical.test.ts
@@ -26,6 +26,14 @@ test("other models fall back to the native provider", () => {
   expect(model.provider).toBe("google.vertex.chat");
 });
 
+// Dotted Gemini versions keep their delimiter, so no explicit mapping is needed.
+test("dotted Gemini versions resolve without an explicit mapping", () => {
+  const provider = withCanonicalIdsForVertex(vertex);
+  const model = provider.languageModel("google/gemini-3.7-flash");
+  expect(model.modelId).toBe("gemini-3.7-flash");
+  expect(model.provider).toBe("google.vertex.chat");
+});
+
 // ---------------------------------------------------------------------------
 // The MaaS override inherits the provider's project and credentials
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds `google/gemini-3.7-flash` to the model catalog.

### Changes

- Canonical ID `google/gemini-3.7-flash` in `src/models/types.ts`
- `gemini37Flash` preset built on `GEMINI_3X_BASE` (created `2026-08-13`, knowledge `2026-03`, 1M context, Vertex)
- New `v3.7` atomic group, folded into `v3.x`; `gemini.latest` now points at 3.7 Flash
- README preset group list updated

### No middleware or canonical-mapping changes needed

Per the issue's request that a future 3.8 be preset-only, this verifies and locks down the version-agnostic paths:

- Vertex keeps dots for non-Anthropic namespaces, so the default transform already yields the native `gemini-3.7-flash` — no `MAPPING` entry
- The reasoning/prompt-caching matcher is registered for `google/gemini-3*`, which matches any 3.x minor
- `geminiReasoningMiddleware` branches on `includes("gemini-3")` / `includes("pro")`, both minor-agnostic

Added tests cover each of these so a regression that hardcodes minor versions fails.

### Verification

- `bun run build` clean
- `bun test src/models/google/ src/providers/vertex/canonical.test.ts` — 30 pass, 0 fail
- Full `bun run test` has one failure (`vertexGemma4ThinkingMiddleware > enable_thinking reaches the provider`) and 34 lint errors that are both pre-existing on `main` and unrelated to this change.

Metadata sourced from models.dev (`google-vertex`) and OpenRouter.

Closes #247

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Google Gemini 3.7 Flash model.
  * Added Gemini 3.7 Flash to the latest Gemini model group and available model listings.
  * Enabled high-level reasoning configuration with thoughts for Gemini 3.7 Flash.

* **Bug Fixes**
  * Preserved dotted Gemini model identifiers when using the Vertex provider.

* **Documentation**
  * Updated the documented Google Gemini model preset information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->