### PR TITLE
feat(chat-completions): normalize reasoning state across providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,10 +780,38 @@ Most SDKs handle these fields out-of-the-box.
 
 Advanced models (like Anthropic Claude 3.7 or Gemini 3) surface structured reasoning steps and signatures that act as a "save state" for the model's internal reasoning process. To maintain this context across multi-turn conversations and tool-calling workflows, you should pass back the following extensions in subsequent messages:
 
-- **reasoning_details**: Standardized array of reasoning steps and generic signatures.
+- **reasoning_details**: Standardized array of reasoning steps and signatures.
 - **extra_content**: Provider-specific extensions, such as **Google's thought signatures** on Vertex AI.
 
-For **Gemini 3** models, returning the thought signature via `extra_content` is mandatory to resume the chain-of-thought; failing to do so may result in errors or degraded performance.
+On `/chat/completions`, `reasoning_details` follows the convention used by OpenRouter and the Vercel AI Gateway, so most OpenAI-compatible clients round-trip it without any changes. Each entry is tagged with the `format` of the provider that produced it — `anthropic-claude-v1`, `google-gemini-v1`, `openai-responses-v1`, `azure-openai-responses-v1` or `xai-responses-v1` — and carries the opaque state in the field that convention uses:
+
+| Provider         | Opaque state                          | How it is surfaced                                                                                                           |
+| ---------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Anthropic Claude | thinking signature, redacted thinking | `reasoning.text` + `signature`, `reasoning.encrypted` + `data`                                                               |
+| Google Gemini    | thought signature                     | `reasoning.encrypted` + `data`, `id` = the `tool_calls[].id` it belongs to; also `extra_content.vertex.thought_signature`    |
+| OpenAI GPT       | encrypted reasoning trace             | `reasoning.encrypted` + `data`, `id` = the reasoning item id, alongside the `reasoning.text` summary entry sharing that `id` |
+
+Echo the array back on the assistant message and the gateway restores the provider state, matching entries by `id`.
+
+For **Gemini 3** models, returning the thought signature is mandatory to resume the chain-of-thought; failing to do so may result in errors or degraded performance. The gateway exposes it in two interchangeable ways and you only need to echo back one of them — `reasoning_details`, or the Vertex-specific `extra_content.vertex.thought_signature` on the tool call. When both are present, `extra_content` takes precedence.
+
+```json
+{
+  "role": "assistant",
+  "tool_calls": [
+    { "id": "call_abc", "type": "function", "function": { "name": "bash", "arguments": "{}" } }
+  ],
+  "reasoning_details": [
+    {
+      "id": "call_abc",
+      "index": 0,
+      "type": "reasoning.encrypted",
+      "data": "AY89a18IwQsQ8in...",
+      "format": "google-gemini-v1"
+    }
+  ]
+}
+```
 
 ### Service Tier
 

--- a/src/endpoints/chat-completions/converters.test.ts
+++ b/src/endpoints/chat-completions/converters.test.ts
@@ -410,6 +410,30 @@ describe("Chat Completions Converters", () => {
       ]);
     });
 
+    test("should emit Anthropic redacted thinking from reasoning-start", async () => {
+      const deltas = await streamDeltas([
+        {
+          type: "reasoning-start",
+          id: "0",
+          providerMetadata: { anthropic: { redactedData: "redacted-blob" } },
+        },
+        { type: "reasoning-start", id: "1" },
+        { type: "reasoning-delta", id: "1", text: "Thinking..." },
+      ] as unknown as TextStreamPart<ToolSet>[]);
+
+      expect(deltas).toHaveLength(2);
+      expect(deltas[0]!.reasoning_details).toEqual([
+        {
+          id: "0",
+          index: 0,
+          type: "reasoning.encrypted",
+          data: "redacted-blob",
+          format: "anthropic-claude-v1",
+        },
+      ]);
+      expect(deltas[1]!.reasoning).toBe("Thinking...");
+    });
+
     test("should emit OpenAI encrypted reasoning once, on reasoning-end", async () => {
       const providerMetadata = {
         openai: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-trace" },

--- a/src/endpoints/chat-completions/converters.test.ts
+++ b/src/endpoints/chat-completions/converters.test.ts
@@ -8,10 +8,12 @@ import type {
   FilePart,
   LanguageModelUsage,
   AssistantModelMessage,
+  TextStreamPart,
 } from "ai";
 
 import type { RuntimeContext } from "../shared/converters";
 import {
+  ChatCompletionsTransformStream,
   convertToTextCallOptions,
   toChatCompletions,
   toChatCompletionsAssistantMessage,
@@ -20,7 +22,7 @@ import {
   fromChatCompletionsAssistantMessage,
   fromChatCompletionsToolResultMessage,
 } from "./converters";
-import type { ChatCompletionsToolMessage } from "./schema";
+import type { ChatCompletionsAssistantMessageDelta, ChatCompletionsToolMessage } from "./schema";
 
 const mockUsage = (overrides: Partial<LanguageModelUsage> = {}): LanguageModelUsage =>
   ({
@@ -80,6 +82,22 @@ const mockGenerateTextResult = (
     ...result,
     finalStep: { ...result, stepNumber: 0 },
   } as unknown as GenerateTextResult<ToolSet, RuntimeContext, Output.Output>;
+};
+
+const streamDeltas = async (parts: TextStreamPart<ToolSet>[]) => {
+  const source = new ReadableStream<TextStreamPart<ToolSet>>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  });
+
+  const deltas: ChatCompletionsAssistantMessageDelta[] = [];
+  for await (const frame of source.pipeThrough(new ChatCompletionsTransformStream("mock"))) {
+    if (frame.data instanceof Error) throw frame.data;
+    deltas.push(frame.data.choices[0]!.delta);
+  }
+  return deltas;
 };
 
 describe("Chat Completions Converters", () => {
@@ -260,7 +278,7 @@ describe("Chat Completions Converters", () => {
         type: "reasoning.text",
         text: "I am thinking...",
         signature: "sig-123",
-        format: "unknown",
+        format: "anthropic-claude-v1",
         index: 0,
       });
       expect(message.reasoning_details![0]!.id).toStartWith("reasoning-");
@@ -291,6 +309,128 @@ describe("Chat Completions Converters", () => {
       expect(message.reasoning_details![0]!.text).toBeUndefined();
       expect(message.reasoning_details![0]!.signature).toBeUndefined();
     });
+
+    test("should mirror a tool call thought signature into reasoning_details", () => {
+      const mockResult = mockGenerateTextResult({
+        finishReason: "tool-calls",
+        toolCalls: [
+          {
+            type: "tool-call",
+            toolCallId: "call_123",
+            toolName: "get_weather",
+            input: { location: "London" },
+            providerMetadata: { vertex: { thought_signature: "tool-signature" } },
+          },
+        ],
+      });
+
+      const message = toChatCompletionsAssistantMessage(mockResult);
+
+      expect(message.reasoning_details).toEqual([
+        {
+          id: "call_123",
+          index: 0,
+          type: "reasoning.encrypted",
+          data: "tool-signature",
+          format: "google-gemini-v1",
+        },
+      ]);
+    });
+
+    test("should emit OpenAI encrypted reasoning once per item", () => {
+      const providerMetadata = {
+        openai: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-trace" },
+      };
+      const mockResult = mockGenerateTextResult({
+        content: [
+          { type: "reasoning", text: "First summary.", providerMetadata },
+          { type: "reasoning", text: "Second summary.", providerMetadata },
+        ],
+      });
+
+      const message = toChatCompletionsAssistantMessage(mockResult);
+
+      expect(message.reasoning_details).toEqual([
+        {
+          id: "rs_1",
+          index: 0,
+          type: "reasoning.text",
+          text: "First summary.",
+          signature: undefined,
+          format: "openai-responses-v1",
+        },
+        {
+          id: "rs_1",
+          index: 1,
+          type: "reasoning.encrypted",
+          data: "encrypted-trace",
+          format: "openai-responses-v1",
+        },
+        {
+          id: "rs_1",
+          index: 2,
+          type: "reasoning.text",
+          text: "Second summary.",
+          signature: undefined,
+          format: "openai-responses-v1",
+        },
+      ]);
+    });
+  });
+
+  describe("ChatCompletionsTransformStream", () => {
+    test("should emit a thought signature detail alongside the tool call", async () => {
+      const deltas = await streamDeltas([
+        {
+          type: "reasoning-delta",
+          id: "r1",
+          text: "Thinking...",
+          providerMetadata: { vertex: {} },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "call_123",
+          toolName: "get_weather",
+          input: { location: "London" },
+          providerMetadata: { vertex: { thought_signature: "tool-signature" } },
+        },
+      ] as unknown as TextStreamPart<ToolSet>[]);
+
+      expect(deltas[0]!.reasoning_details![0]!.index).toBe(0);
+      expect(deltas[1]!.tool_calls![0]!.id).toBe("call_123");
+      // A separate index, so clients merging deltas by index keep them apart.
+      expect(deltas[1]!.reasoning_details).toEqual([
+        {
+          id: "call_123",
+          index: 1,
+          type: "reasoning.encrypted",
+          data: "tool-signature",
+          format: "google-gemini-v1",
+        },
+      ]);
+    });
+
+    test("should emit OpenAI encrypted reasoning once, on reasoning-end", async () => {
+      const providerMetadata = {
+        openai: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-trace" },
+      };
+      const deltas = await streamDeltas([
+        { type: "reasoning-delta", id: "rs_1:0", text: "Summary.", providerMetadata },
+        { type: "reasoning-end", id: "rs_1:0", providerMetadata },
+        { type: "reasoning-end", id: "rs_1:1", providerMetadata },
+      ] as unknown as TextStreamPart<ToolSet>[]);
+
+      expect(deltas).toHaveLength(2);
+      expect(deltas[1]!.reasoning_details).toEqual([
+        {
+          id: "rs_1",
+          index: 1,
+          type: "reasoning.encrypted",
+          data: "encrypted-trace",
+          format: "openai-responses-v1",
+        },
+      ]);
+    });
   });
 
   describe("fromChatCompletionsAssistantMessage", () => {
@@ -318,6 +458,7 @@ describe("Chat Completions Converters", () => {
         providerOptions: {
           unknown: {
             signature: "sig-xyz",
+            thoughtSignature: "sig-xyz",
           },
         },
       });
@@ -349,8 +490,123 @@ describe("Chat Completions Converters", () => {
         providerOptions: {
           unknown: {
             redactedData: "secret-data",
+            reasoningEncryptedContent: "secret-data",
           },
         },
+      });
+    });
+
+    test("should reattach a gemini thought signature to its tool call", () => {
+      const message = fromChatCompletionsAssistantMessage({
+        role: "assistant",
+        content: null,
+        reasoning_details: [
+          {
+            id: "call_1",
+            index: 0,
+            type: "reasoning.encrypted",
+            data: "thought-sig",
+            format: "google-gemini-v1",
+          },
+        ],
+        tool_calls: [
+          { id: "call_1", type: "function", function: { name: "bash", arguments: "{}" } },
+          { id: "call_2", type: "function", function: { name: "bash", arguments: "{}" } },
+        ],
+      });
+
+      const content = message.content;
+      // The signature entry becomes tool call options, never a reasoning part.
+      expect(content).toHaveLength(2);
+      expect(content[0]).toMatchObject({
+        type: "tool-call",
+        toolCallId: "call_1",
+        providerOptions: { unknown: { thoughtSignature: "thought-sig" } },
+      });
+      expect(content[1]).toEqual({
+        type: "tool-call",
+        toolCallId: "call_2",
+        toolName: "bash",
+        input: {},
+      });
+    });
+
+    test("should prefer extra_content over reasoning_details for tool call signatures", () => {
+      const message = fromChatCompletionsAssistantMessage({
+        role: "assistant",
+        content: null,
+        reasoning_details: [
+          {
+            id: "call_1",
+            index: 0,
+            type: "reasoning.encrypted",
+            data: "from-details",
+            format: "google-gemini-v1",
+          },
+        ],
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "bash", arguments: "{}" },
+            extra_content: { vertex: { thought_signature: "from-extra-content" } },
+          },
+        ],
+      });
+
+      expect(message.content[0]).toMatchObject({
+        providerOptions: { vertex: { thought_signature: "from-extra-content" } },
+      });
+    });
+
+    test("should merge OpenAI text and encrypted entries onto one reasoning part", () => {
+      const message = fromChatCompletionsAssistantMessage({
+        role: "assistant",
+        content: "Done.",
+        reasoning_details: [
+          {
+            id: "rs_1",
+            index: 0,
+            type: "reasoning.text",
+            text: "Summary.",
+            format: "openai-responses-v1",
+          },
+          {
+            id: "rs_1",
+            index: 1,
+            type: "reasoning.encrypted",
+            data: "encrypted-trace",
+            format: "openai-responses-v1",
+          },
+        ],
+      });
+
+      const content = message.content;
+      expect(content).toHaveLength(2);
+      expect(content[0]).toEqual({
+        type: "reasoning",
+        text: "Summary.",
+        providerOptions: {
+          unknown: {
+            itemId: "rs_1",
+            redactedData: "encrypted-trace",
+            reasoningEncryptedContent: "encrypted-trace",
+          },
+        },
+      });
+    });
+
+    test("should push a message-level thought signature onto the text part", () => {
+      const message = fromChatCompletionsAssistantMessage({
+        role: "assistant",
+        content: "Let me check the weather.",
+        extra_content: { vertex: { thought_signature: "text-sig" } },
+      });
+
+      expect(message.content[0]).toEqual({
+        type: "text",
+        text: "Let me check the weather.",
+        providerOptions: { unknown: { thoughtSignature: "text-sig" } },
       });
     });
 

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -1,4 +1,4 @@
-import type { SharedV4ProviderMetadata } from "@ai-sdk/provider";
+import type { JSONObject, SharedV4ProviderMetadata } from "@ai-sdk/provider";
 import type {
   GenerateTextResult,
   StreamTextResult,
@@ -33,6 +33,8 @@ import {
   parseBase64,
   parseImageInput,
   extractReasoningMetadata,
+  GEMINI_REASONING_FORMAT,
+  type ReasoningMetadata,
   type RuntimeContext,
   type TextCallOptions,
   type ToolChoiceOptions,
@@ -195,41 +197,73 @@ export function fromChatCompletionsUserMessage(
   return out;
 }
 
+/** `ai` does not re-export its assistant content part types; narrow them out instead. */
+type ReasoningPart = Extract<Exclude<AssistantContent, string>[number], { type: "reasoning" }>;
+
+/**
+ * Turns a `reasoning_details` entry's opaque blobs into provider options.
+ *
+ * Every provider key for a slot is written rather than picking one from `format`:
+ * clients routinely flatten the tag, each provider reads only the key it knows, and
+ * provider option schemas strip the keys they do not.
+ */
+function toReasoningOptions(detail: ChatCompletionsReasoningDetail): Record<string, string> {
+  const options: Record<string, string> = {};
+  if (detail.signature) {
+    options["signature"] = detail.signature;
+    options["thoughtSignature"] = detail.signature;
+  }
+  if (detail.data) {
+    options["redactedData"] = detail.data;
+    options["reasoningEncryptedContent"] = detail.data;
+  }
+  if (detail.id) options["itemId"] = detail.id;
+  return options;
+}
+
 export function fromChatCompletionsAssistantMessage(
   message: ChatCompletionsAssistantMessage,
 ): AssistantModelMessage {
   const { tool_calls, role, content, extra_content, reasoning_details, cache_control } = message;
 
   const parts: AssistantContent = [];
+  /** Gemini thought signatures, keyed by the tool call they belong to. */
+  const thoughtSignatures = new Map<string, string>();
+  /** Reasoning parts by id, so OpenAI's text and encrypted entries merge back into one. */
+  const reasoningById = new Map<string, ReasoningPart>();
 
-  if (reasoning_details?.length) {
-    for (const detail of reasoning_details) {
-      if (detail.text && detail.type === "reasoning.text") {
-        parts.push({
-          type: "reasoning",
-          text: detail.text,
-          providerOptions: detail.signature
-            ? {
-                unknown: {
-                  signature: detail.signature,
-                },
-              }
-            : undefined,
-        });
-      } else if (detail.type === "reasoning.encrypted" && detail.data) {
-        parts.push({
-          type: "reasoning",
-          text: "",
-          providerOptions: {
-            unknown: {
-              redactedData: detail.data,
-            },
-          },
-        });
-      }
+  for (const detail of reasoning_details ?? []) {
+    // Gemini hangs its thought signature off a tool call rather than a reasoning block,
+    // so it travels as an encrypted entry carrying that call's id.
+    if (detail.type === "reasoning.encrypted" && detail.format === GEMINI_REASONING_FORMAT) {
+      if (detail.id && detail.data) thoughtSignatures.set(detail.id, detail.data);
+      continue;
     }
+
+    if (!detail.text && !detail.data) continue;
+    const options = toReasoningOptions(detail);
+
+    // OpenAI splits one reasoning item into a text entry and an encrypted entry sharing
+    // an id, and wants them back on a single part.
+    const existing = detail.id ? reasoningById.get(detail.id) : undefined;
+    if (existing) {
+      existing.text ||= detail.text ?? "";
+      existing.providerOptions = {
+        unknown: {
+          ...(existing.providerOptions?.["unknown"] as Record<string, string>),
+          ...options,
+        },
+      };
+      continue;
+    }
+
+    const part: ReasoningPart = { type: "reasoning", text: detail.text ?? "" };
+    if (Object.keys(options).length > 0) part.providerOptions = { unknown: options };
+    if (detail.id) reasoningById.set(detail.id, part);
+    parts.push(part);
   }
 
+  let lastTextPart: TextPart | undefined;
   if (content !== undefined && content !== null) {
     const inputContent =
       typeof content === "string"
@@ -247,8 +281,20 @@ export function fromChatCompletionsAssistantMessage(
           };
         }
         parts.push(textPart);
+        lastTextPart = textPart;
       }
     }
+  }
+
+  // Gemini signs plain text too, and that signature travels out on the message's
+  // extra_content. The provider only reads options off content parts, so put it back on
+  // the text that carried it.
+  const { thoughtSignature } = extractReasoningMetadata(extra_content ?? undefined);
+  if (thoughtSignature && lastTextPart) {
+    lastTextPart.providerOptions = {
+      ...lastTextPart.providerOptions,
+      unknown: { ...(lastTextPart.providerOptions?.["unknown"] as JSONObject), thoughtSignature },
+    };
   }
 
   if (tool_calls?.length) {
@@ -261,8 +307,14 @@ export function fromChatCompletionsAssistantMessage(
         toolName: fn.name,
         input: parseJsonOrText(fn.arguments).value,
       };
+      // The provider-specific extra_content wins; otherwise fall back to the thought
+      // signature from reasoning_details. `unknown` is merged into the provider's
+      // namespace by the params middleware, so it reaches Vertex as `thoughtSignature`.
+      const signature = thoughtSignatures.get(id);
       if (extra_content) {
         out.providerOptions = extra_content;
+      } else if (signature) {
+        out.providerOptions = { unknown: { thoughtSignature: signature } };
       }
       parts.push(out);
     }
@@ -513,7 +565,18 @@ export class ChatCompletionsTransformStream extends TransformStream<
     const creationTime = Math.floor(Date.now() / 1000);
     let toolCallIndexCounter = 0;
     const reasoningIdToIndex = new Map<string, number>();
+    const encryptedIds = new Set<string>();
     let finishProviderMetadata: SharedV4ProviderMetadata | undefined;
+
+    /** Reasoning entries share one index space, allocated in order of first appearance. */
+    const reasoningIndex = (key: string): number => {
+      let index = reasoningIdToIndex.get(key);
+      if (index === undefined) {
+        index = reasoningIdToIndex.size;
+        reasoningIdToIndex.set(key, index);
+      }
+      return index;
+    };
 
     const createChunk = (
       delta: ChatCompletionsAssistantMessageDelta,
@@ -558,12 +621,6 @@ export class ChatCompletionsTransformStream extends TransformStream<
           }
 
           case "reasoning-delta": {
-            let index = reasoningIdToIndex.get(part.id);
-            if (index === undefined) {
-              index = reasoningIdToIndex.size;
-              reasoningIdToIndex.set(part.id, index);
-            }
-
             controller.enqueue(
               createChunk(
                 {
@@ -576,12 +633,40 @@ export class ChatCompletionsTransformStream extends TransformStream<
                         providerMetadata: part.providerMetadata,
                       },
                       part.id,
-                      index,
+                      reasoningIndex(part.id),
                     ),
                   ],
                 },
                 part.providerMetadata,
               ),
+            );
+            break;
+          }
+
+          case "reasoning-end": {
+            // OpenAI only reveals its encrypted trace when the item closes, so it never
+            // rides along on a delta — and repeats it for every summary part of the item.
+            const { encryptedContent, itemId, format } = extractReasoningMetadata(
+              part.providerMetadata,
+            );
+            const id = itemId ?? part.id;
+            if (!encryptedContent || encryptedIds.has(id)) break;
+            encryptedIds.add(id);
+
+            controller.enqueue(
+              createChunk({
+                reasoning_details: [
+                  {
+                    id,
+                    // Keyed apart from the text deltas of the same block so the encrypted
+                    // entry gets an index of its own.
+                    index: reasoningIndex(`${id}:encrypted`),
+                    type: "reasoning.encrypted",
+                    data: encryptedContent,
+                    format,
+                  },
+                ],
+              }),
             );
             break;
           }
@@ -594,11 +679,20 @@ export class ChatCompletionsTransformStream extends TransformStream<
               part.providerMetadata,
             ) as ChatCompletionsToolCallDelta;
             toolCall.index = toolCallIndexCounter++;
-            controller.enqueue(
-              createChunk({
-                tool_calls: [toolCall],
-              }),
+
+            // Mirror the tool call's Gemini thought signature into reasoning_details.
+            const delta: ChatCompletionsAssistantMessageDelta = { tool_calls: [toolCall] };
+            const detail = toThoughtSignatureDetail(
+              part.toolCallId,
+              part.providerMetadata,
+              reasoningIdToIndex.size,
             );
+            if (detail) {
+              reasoningIdToIndex.set(`${part.toolCallId}:signature`, detail.index);
+              delta.reasoning_details = [detail];
+            }
+
+            controller.enqueue(createChunk(delta));
             break;
           }
 
@@ -650,6 +744,7 @@ export const toChatCompletionsAssistantMessage = (
   }
 
   const reasoningDetails: ChatCompletionsReasoningDetail[] = [];
+  const encryptedIds = new Set<string>();
 
   for (const part of result.content) {
     if (part.type === "text") {
@@ -662,10 +757,33 @@ export const toChatCompletionsAssistantMessage = (
         message.extra_content = part.providerMetadata;
       }
     } else if (part.type === "reasoning") {
-      reasoningDetails.push(
-        toReasoningDetail(part, `reasoning-${crypto.randomUUID()}`, reasoningDetails.length),
-      );
+      const metadata = extractReasoningMetadata(part.providerMetadata);
+      const id = metadata.itemId ?? `reasoning-${crypto.randomUUID()}`;
+      reasoningDetails.push(toReasoningDetail(part, id, reasoningDetails.length, metadata));
+
+      // OpenAI hands its encrypted trace over *alongside* the summary text rather than
+      // in place of it, repeating it on every summary part of the same item.
+      if (metadata.encryptedContent && !encryptedIds.has(id)) {
+        encryptedIds.add(id);
+        reasoningDetails.push({
+          id,
+          index: reasoningDetails.length,
+          type: "reasoning.encrypted",
+          data: metadata.encryptedContent,
+          format: metadata.format,
+        });
+      }
     }
+  }
+
+  // Appended after the reasoning entries so `index` stays in generation order.
+  for (const toolCall of result.toolCalls ?? []) {
+    const detail = toThoughtSignatureDetail(
+      toolCall.toolCallId,
+      toolCall.providerMetadata,
+      reasoningDetails.length,
+    );
+    if (detail) reasoningDetails.push(detail);
   }
 
   if (result.finalStep.reasoningText) {
@@ -688,26 +806,50 @@ export function toReasoningDetail(
   reasoning: ReasoningOutput,
   id: string,
   index: number,
+  metadata: ReasoningMetadata = extractReasoningMetadata(reasoning.providerMetadata),
 ): ChatCompletionsReasoningDetail {
-  const { redactedData, signature } = extractReasoningMetadata(reasoning.providerMetadata);
+  const { redactedData, signature, thoughtSignature, itemId, format } = metadata;
+  // OpenAI's reasoning item id is the correlation key clients must echo back, so it
+  // wins over the synthetic one.
+  const detailId = itemId ?? id;
 
+  // Anthropic sends redacted thinking *instead of* the text.
   if (redactedData) {
-    return {
-      id,
-      index,
-      type: "reasoning.encrypted",
-      data: redactedData,
-      format: "unknown",
-    };
+    return { id: detailId, index, type: "reasoning.encrypted", data: redactedData, format };
   }
 
   return {
-    id,
+    id: detailId,
     index,
     type: "reasoning.text",
     text: reasoning.text,
-    signature,
-    format: "unknown",
+    // Gemini calls its signature a thought signature; it plays the same role here.
+    signature: signature ?? thoughtSignature,
+    format,
+  };
+}
+
+/**
+ * Gemini hangs its thought signature off the tool call rather than off a reasoning
+ * block. Mirror it into a `reasoning_details` entry so OpenAI-compatible clients
+ * round-trip it: both OpenRouter and the Vercel AI Gateway use `reasoning.encrypted`
+ * with the blob in `data`, and OpenRouter sets `id` to the tool call it belongs to so it
+ * can be reattached to the right call on the next turn.
+ */
+export function toThoughtSignatureDetail(
+  toolCallId: string,
+  providerMetadata: SharedV4ProviderMetadata | undefined,
+  index: number,
+): ChatCompletionsReasoningDetail | undefined {
+  const { thoughtSignature } = extractReasoningMetadata(providerMetadata);
+  if (!thoughtSignature) return undefined;
+
+  return {
+    id: toolCallId,
+    index,
+    type: "reasoning.encrypted",
+    data: thoughtSignature,
+    format: GEMINI_REASONING_FORMAT,
   };
 }
 

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -34,6 +34,7 @@ import {
   parseImageInput,
   extractReasoningMetadata,
   GEMINI_REASONING_FORMAT,
+  type ReasoningFormat,
   type ReasoningMetadata,
   type RuntimeContext,
   type TextCallOptions,
@@ -511,6 +512,17 @@ function parseToolResult(
 
 // --- Response Flow ---
 
+/**
+ * The single wire shape every opaque reasoning blob leaves as: Anthropic's redacted
+ * thinking, OpenAI's encrypted trace and Gemini's thought signature.
+ */
+const encryptedReasoningDetail = (
+  id: string,
+  index: number,
+  data: string,
+  format: ReasoningFormat,
+): ChatCompletionsReasoningDetail => ({ id, index, type: "reasoning.encrypted", data, format });
+
 export function toChatCompletions(
   result: GenerateTextResult<ToolSet, RuntimeContext, Output.Output>,
   model: string,
@@ -653,19 +665,12 @@ export class ChatCompletionsTransformStream extends TransformStream<
             if (!encryptedContent || encryptedIds.has(id)) break;
             encryptedIds.add(id);
 
+            // Keyed apart from the text deltas of the same block so the encrypted entry
+            // gets an index of its own.
+            const index = reasoningIndex(`${id}:encrypted`);
             controller.enqueue(
               createChunk({
-                reasoning_details: [
-                  {
-                    id,
-                    // Keyed apart from the text deltas of the same block so the encrypted
-                    // entry gets an index of its own.
-                    index: reasoningIndex(`${id}:encrypted`),
-                    type: "reasoning.encrypted",
-                    data: encryptedContent,
-                    format,
-                  },
-                ],
+                reasoning_details: [encryptedReasoningDetail(id, index, encryptedContent, format)],
               }),
             );
             break;
@@ -765,13 +770,14 @@ export const toChatCompletionsAssistantMessage = (
       // in place of it, repeating it on every summary part of the same item.
       if (metadata.encryptedContent && !encryptedIds.has(id)) {
         encryptedIds.add(id);
-        reasoningDetails.push({
-          id,
-          index: reasoningDetails.length,
-          type: "reasoning.encrypted",
-          data: metadata.encryptedContent,
-          format: metadata.format,
-        });
+        reasoningDetails.push(
+          encryptedReasoningDetail(
+            id,
+            reasoningDetails.length,
+            metadata.encryptedContent,
+            metadata.format,
+          ),
+        );
       }
     }
   }
@@ -815,7 +821,7 @@ export function toReasoningDetail(
 
   // Anthropic sends redacted thinking *instead of* the text.
   if (redactedData) {
-    return { id: detailId, index, type: "reasoning.encrypted", data: redactedData, format };
+    return encryptedReasoningDetail(detailId, index, redactedData, format);
   }
 
   return {
@@ -844,13 +850,7 @@ export function toThoughtSignatureDetail(
   const { thoughtSignature } = extractReasoningMetadata(providerMetadata);
   if (!thoughtSignature) return undefined;
 
-  return {
-    id: toolCallId,
-    index,
-    type: "reasoning.encrypted",
-    data: thoughtSignature,
-    format: GEMINI_REASONING_FORMAT,
-  };
+  return encryptedReasoningDetail(toolCallId, index, thoughtSignature, GEMINI_REASONING_FORMAT);
 }
 
 export function toChatCompletionsUsage(usage: LanguageModelUsage): ChatCompletionsUsage {

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -632,6 +632,28 @@ export class ChatCompletionsTransformStream extends TransformStream<
             break;
           }
 
+          case "reasoning-start": {
+            // Anthropic hands redacted thinking over as the block opens, in place of any
+            // text, so no delta ever carries it.
+            const { redactedData, format } = extractReasoningMetadata(part.providerMetadata);
+            if (!redactedData || encryptedIds.has(part.id)) break;
+            encryptedIds.add(part.id);
+
+            controller.enqueue(
+              createChunk({
+                reasoning_details: [
+                  encryptedReasoningDetail(
+                    part.id,
+                    reasoningIndex(`${part.id}:encrypted`),
+                    redactedData,
+                    format,
+                  ),
+                ],
+              }),
+            );
+            break;
+          }
+
           case "reasoning-delta": {
             controller.enqueue(
               createChunk(
@@ -687,14 +709,18 @@ export class ChatCompletionsTransformStream extends TransformStream<
 
             // Mirror the tool call's Gemini thought signature into reasoning_details.
             const delta: ChatCompletionsAssistantMessageDelta = { tool_calls: [toolCall] };
-            const detail = toThoughtSignatureDetail(
-              part.toolCallId,
-              part.providerMetadata,
-              reasoningIdToIndex.size,
-            );
-            if (detail) {
-              reasoningIdToIndex.set(`${part.toolCallId}:signature`, detail.index);
-              delta.reasoning_details = [detail];
+            const { thoughtSignature } = extractReasoningMetadata(part.providerMetadata);
+            if (thoughtSignature) {
+              delta.reasoning_details = [
+                encryptedReasoningDetail(
+                  part.toolCallId,
+                  // Keyed apart from the reasoning blocks so the signature gets an index of
+                  // its own, and allocated through the shared counter so it cannot collide.
+                  reasoningIndex(`${part.toolCallId}:signature`),
+                  thoughtSignature,
+                  GEMINI_REASONING_FORMAT,
+                ),
+              ];
             }
 
             controller.enqueue(createChunk(delta));

--- a/src/endpoints/shared/converters.test.ts
+++ b/src/endpoints/shared/converters.test.ts
@@ -220,14 +220,29 @@ describe("Shared Converters", () => {
     });
 
     test("should read the snakized spellings the params middleware produces", () => {
-      const metadata = {
-        vertex: { thought_signature: "sig" },
-        anthropic: { redacted_data: "data" },
-      };
-      expect(extractReasoningMetadata(metadata)).toMatchObject({
+      expect(extractReasoningMetadata({ vertex: { thought_signature: "sig" } })).toMatchObject({
         thoughtSignature: "sig",
         format: "google-gemini-v1",
       });
+      expect(extractReasoningMetadata({ anthropic: { redacted_data: "data" } })).toMatchObject({
+        redactedData: "data",
+        format: "anthropic-claude-v1",
+      });
+      expect(
+        extractReasoningMetadata({
+          openai: { item_id: "rs_1", reasoning_encrypted_content: "blob" },
+        }),
+      ).toMatchObject({
+        itemId: "rs_1",
+        encryptedContent: "blob",
+        format: "openai-responses-v1",
+      });
+    });
+
+    test("should keep scanning past an empty artifact", () => {
+      expect(
+        extractReasoningMetadata({ openai: { signature: "", reasoningEncryptedContent: "blob" } }),
+      ).toMatchObject({ encryptedContent: "blob", format: "openai-responses-v1" });
     });
 
     test("should tag the format from the provider namespace", () => {

--- a/src/endpoints/shared/converters.test.ts
+++ b/src/endpoints/shared/converters.test.ts
@@ -212,15 +212,36 @@ describe("Shared Converters", () => {
       const metadata = {
         provider: { redactedData: "data", signature: "sig" },
       };
-      expect(extractReasoningMetadata(metadata)).toEqual({
+      expect(extractReasoningMetadata(metadata)).toMatchObject({
         redactedData: "data",
         signature: "sig",
+        format: "unknown",
       });
     });
 
-    test("should return empty object if not found", () => {
-      expect(extractReasoningMetadata({})).toEqual({});
-      expect(extractReasoningMetadata()).toEqual({});
+    test("should read the snakized spellings the params middleware produces", () => {
+      const metadata = {
+        vertex: { thought_signature: "sig" },
+        anthropic: { redacted_data: "data" },
+      };
+      expect(extractReasoningMetadata(metadata)).toMatchObject({
+        thoughtSignature: "sig",
+        format: "google-gemini-v1",
+      });
+    });
+
+    test("should tag the format from the provider namespace", () => {
+      expect(extractReasoningMetadata({ anthropic: { signature: "sig" } }).format).toBe(
+        "anthropic-claude-v1",
+      );
+      expect(
+        extractReasoningMetadata({ openai: { reasoningEncryptedContent: "blob" } }),
+      ).toMatchObject({ encryptedContent: "blob", format: "openai-responses-v1" });
+    });
+
+    test("should return only the format if not found", () => {
+      expect(extractReasoningMetadata({})).toEqual({ format: "unknown" });
+      expect(extractReasoningMetadata()).toEqual({ format: "unknown" });
     });
   });
 });

--- a/src/endpoints/shared/converters.ts
+++ b/src/endpoints/shared/converters.ts
@@ -325,7 +325,7 @@ export function extractReasoningMetadata(
       metadata["thoughtSignature"] ?? metadata["thought_signature"],
     );
 
-    if (signature ?? redactedData ?? encryptedContent ?? itemId ?? thoughtSignature) {
+    if (signature || redactedData || encryptedContent || itemId || thoughtSignature) {
       return {
         signature,
         redactedData,

--- a/src/endpoints/shared/converters.ts
+++ b/src/endpoints/shared/converters.ts
@@ -252,32 +252,90 @@ export function stripEmptyKeys(obj: unknown) {
   return obj;
 }
 
-export function extractReasoningMetadata(providerMetadata?: SharedV4ProviderMetadata): {
-  redactedData?: string;
+/**
+ * `reasoning_details[].format` tags, as enumerated by OpenRouter. Clients use them to
+ * tell which convention an opaque reasoning blob follows.
+ * https://openrouter.ai/docs/use-cases/reasoning-tokens
+ */
+export type ReasoningFormat =
+  | "unknown"
+  | "anthropic-claude-v1"
+  | "google-gemini-v1"
+  | "openai-responses-v1"
+  | "azure-openai-responses-v1"
+  | "xai-responses-v1";
+
+export const GEMINI_REASONING_FORMAT = "google-gemini-v1";
+
+/**
+ * Format tag per AI SDK provider metadata namespace. The params middleware renames
+ * metadata *values* but never the namespaces, so these are the ones providers emit.
+ */
+const REASONING_FORMATS: Record<string, ReasoningFormat> = {
+  anthropic: "anthropic-claude-v1",
+  // Claude on Bedrock. GPT on Bedrock runs through Mantle, which reports as `openai`.
+  bedrock: "anthropic-claude-v1",
+  google: GEMINI_REASONING_FORMAT,
+  vertex: GEMINI_REASONING_FORMAT,
+  openai: "openai-responses-v1",
+  azure: "azure-openai-responses-v1",
+  xai: "xai-responses-v1",
+};
+
+export type ReasoningMetadata = {
+  /** Anthropic thinking signature. */
   signature?: string;
-} {
-  if (!providerMetadata) return {};
+  /** Anthropic redacted thinking. */
+  redactedData?: string;
+  /** OpenAI encrypted reasoning trace. */
+  encryptedContent?: string;
+  /** OpenAI reasoning item id, the correlation key for its trace. */
+  itemId?: string;
+  /** Gemini thought signature. */
+  thoughtSignature?: string;
+  /** Convention followed by the blobs above, from the namespace they were found in. */
+  format: ReasoningFormat;
+};
 
-  for (const metadata of Object.values(providerMetadata)) {
-    if (metadata && typeof metadata === "object") {
-      let redactedData: string | undefined;
-      let signature: string | undefined;
-      let found = false;
+const NO_REASONING_METADATA: ReasoningMetadata = { format: "unknown" };
 
-      if ("redactedData" in metadata && typeof metadata["redactedData"] === "string") {
-        redactedData = metadata["redactedData"];
-        found = true;
-      }
-      if ("signature" in metadata && typeof metadata["signature"] === "string") {
-        signature = metadata["signature"];
-        found = true;
-      }
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
 
-      if (found) {
-        return { redactedData, signature };
-      }
+/**
+ * Collects the opaque reasoning artifacts a provider attaches to a reasoning, text or
+ * tool-call part. Namespaces are scanned rather than named so a new host of the same
+ * model needs no code change; both spellings of each key are read because the params
+ * middleware snakizes response metadata.
+ */
+export function extractReasoningMetadata(
+  providerMetadata?: SharedV4ProviderMetadata,
+): ReasoningMetadata {
+  for (const namespace in providerMetadata) {
+    const metadata = providerMetadata[namespace];
+    if (!metadata || typeof metadata !== "object") continue;
+
+    const signature = asString(metadata["signature"]);
+    const redactedData = asString(metadata["redactedData"] ?? metadata["redacted_data"]);
+    const encryptedContent = asString(
+      metadata["reasoningEncryptedContent"] ?? metadata["reasoning_encrypted_content"],
+    );
+    const itemId = asString(metadata["itemId"] ?? metadata["item_id"]);
+    const thoughtSignature = asString(
+      metadata["thoughtSignature"] ?? metadata["thought_signature"],
+    );
+
+    if (signature ?? redactedData ?? encryptedContent ?? itemId ?? thoughtSignature) {
+      return {
+        signature,
+        redactedData,
+        encryptedContent,
+        itemId,
+        thoughtSignature,
+        format: REASONING_FORMATS[namespace] ?? "unknown",
+      };
     }
   }
 
-  return {};
+  return NO_REASONING_METADATA;
 }

--- a/test/e2e/chat-completions/chat-completions-gemini.test.ts
+++ b/test/e2e/chat-completions/chat-completions-gemini.test.ts
@@ -109,6 +109,78 @@ describe.skipIf(!hasVertexCredentials)("Chat Completions E2E (Vertex - thought_s
   );
 
   // =========================================================================
+  // thought_signature pass: roundtrip via reasoning_details only (no extra_content),
+  // which is what OpenAI-compatible clients echo back on their own.
+  // =========================================================================
+  test(
+    "thought_signature: reasoning_details alone is enough to resume the tool call",
+    async () => {
+      const turn1 = (await client.chat.completions.create({
+        model: VERTEX_MODEL,
+        max_completion_tokens: 1024,
+        messages: [{ role: "user", content: "What's the weather in Madrid?" }],
+        tools: [WEATHER_TOOL],
+        // @ts-expect-error — gateway extension
+        reasoning: { enabled: true, max_tokens: 2048 },
+      })) as OpenAI.Chat.Completions.ChatCompletion & {
+        choices: {
+          message: {
+            tool_calls?: OpenAI.Chat.Completions.ChatCompletionMessageToolCall[];
+            reasoning_details?: {
+              id?: string;
+              type: string;
+              data?: string;
+              format?: string;
+              index: number;
+            }[];
+          };
+        }[];
+      };
+
+      expect(turn1.choices[0]!.finish_reason).toBe("tool_calls");
+      const message = turn1.choices[0]!.message;
+      const toolCall = message.tool_calls?.[0] as ChatCompletionMessageFunctionToolCall;
+      expect(toolCall).toBeDefined();
+
+      // The signature is normalized into reasoning_details, keyed by tool call id.
+      const signatureDetail = message.reasoning_details?.find(
+        (detail) => detail.format === "google-gemini-v1" && detail.type === "reasoning.encrypted",
+      );
+      expect(signatureDetail?.data).toBeDefined();
+      expect(signatureDetail?.id).toBe(toolCall.id);
+
+      // Turn 2: echo back reasoning_details only — the tool call carries no extra_content,
+      // which is the exact scenario an OpenAI-compatible client produces.
+      const assistantMsg = {
+        role: "assistant" as const,
+        tool_calls: [{ id: toolCall.id, type: "function" as const, function: toolCall.function }],
+        reasoning_details: message.reasoning_details,
+      };
+
+      const turn2 = await client.chat.completions.create({
+        model: VERTEX_MODEL,
+        max_completion_tokens: 256,
+        messages: [
+          { role: "user", content: "What's the weather in Madrid?" },
+          assistantMsg as unknown as OpenAI.Chat.Completions.ChatCompletionMessageParam,
+          {
+            role: "tool",
+            tool_call_id: toolCall.id,
+            content: "Madrid: 27°C, sunny",
+          },
+        ],
+        tools: [WEATHER_TOOL],
+        // @ts-expect-error — gateway extension
+        reasoning: { enabled: true, max_tokens: 2048 },
+      });
+
+      expect(turn2.choices[0]!.finish_reason).toBe("stop");
+      expect(turn2.choices[0]!.message.content!.toLowerCase()).toContain("madrid");
+    },
+    { timeout: 120_000 },
+  );
+
+  // =========================================================================
   // thought_signature fail: corrupted thought_signature causes provider error
   // =========================================================================
   test(


### PR DESCRIPTION
Closes #226.

Maps provider reasoning state onto the OpenRouter `reasoning_details` convention in both directions, so OpenAI-compatible clients can resume multi-turn Gemini tool calling without client changes.

- **Gemini thought signatures** ride out as a `reasoning.encrypted` entry keyed by `tool_calls[].id` (streaming and non-streaming) and are reattached to that call on the way back in. `extra_content` still takes precedence.
- **OpenAI encrypted reasoning** (`reasoningEncryptedContent` + reasoning `itemId`) was dropped in both directions; it is now emitted beside the summary entry, deduplicated per item, and merged back onto one part.
- **`format`** is derived from the provider namespace instead of always being `"unknown"`.
- **Reasoning and text part signatures** from Gemini are no longer lost.
- `extractReasoningMetadata` also reads the snakized spellings the params middleware produces.

A follow-up commit collapses the four `reasoning.encrypted` literal sites into a single constructor, so the wire shape is stated once.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preserved provider-specific reasoning metadata across Chat Completions requests, responses, and streaming.
  - Added support for Anthropic signatures, Gemini thought signatures, and OpenAI encrypted or redacted reasoning.
  - Improved restoration of reasoning details and their association with tool calls.

- **Documentation**
  - Expanded guidance and examples for reasoning metadata, provider formats, and Gemini thought signatures.

- **Tests**
  - Added coverage for reasoning conversion, streaming behavior, and end-to-end Gemini tool-call flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->