### PR TITLE
Add Gemma 4 reasoning support across providers

### DIFF
--- a/src/endpoints/chat-completions/converters.test.ts
+++ b/src/endpoints/chat-completions/converters.test.ts
@@ -15,6 +15,7 @@ import {
   convertToTextCallOptions,
   toChatCompletions,
   toChatCompletionsAssistantMessage,
+  ChatCompletionsTransformStream,
   toChatCompletionsToolCall,
   toChatCompletionsUsage,
   fromChatCompletionsAssistantMessage,
@@ -291,6 +292,87 @@ describe("Chat Completions Converters", () => {
       expect(message.reasoning_details![0]!.text).toBeUndefined();
       expect(message.reasoning_details![0]!.signature).toBeUndefined();
     });
+
+    test("should surface normalized final-step reasoning separately from content", () => {
+      const message = toChatCompletionsAssistantMessage(
+        mockGenerateTextResult({
+          text: "Final answer.",
+          content: [{ type: "text", text: "Final answer." }],
+          reasoning: [{ type: "reasoning", text: "I am thinking..." }],
+        }),
+      );
+
+      expect(message).toMatchObject({
+        content: "Final answer.",
+        reasoning: "I am thinking...",
+        reasoning_details: [
+          {
+            type: "reasoning.text",
+            text: "I am thinking...",
+            index: 0,
+          },
+        ],
+      });
+    });
+  });
+
+  describe("ChatCompletionsTransformStream", () => {
+    test("should keep reasoning deltas separate from text deltas", async () => {
+      const input = new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "reasoning-delta", id: "r1", text: "Think first. " });
+          controller.enqueue({ type: "text-delta", id: "t1", text: "Final answer." });
+          controller.close();
+        },
+      });
+
+      const output = input.pipeThrough(
+        new ChatCompletionsTransformStream("google/gemma-4-26b-a4b"),
+      );
+      const chunks = [];
+      for await (const frame of output) {
+        const data = frame.data;
+        if (data instanceof Error) throw new Error(data.message);
+        chunks.push(data.choices[0]!.delta);
+      }
+
+      expect(chunks).toEqual([
+        {
+          reasoning: "Think first. ",
+          reasoning_details: [
+            {
+              id: "r1",
+              index: 0,
+              type: "reasoning.text",
+              text: "Think first. ",
+              format: "unknown",
+            },
+          ],
+        },
+        { role: "assistant", content: "Final answer." },
+      ]);
+    });
+
+    test("should keep non-reasoning streams unchanged", async () => {
+      const input = new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "text-delta", id: "t1", text: "Final answer." });
+          controller.close();
+        },
+      });
+
+      const output = input.pipeThrough(
+        new ChatCompletionsTransformStream("google/gemma-4-26b-a4b"),
+      );
+      const chunks = [];
+      for await (const frame of output) {
+        const data = frame.data;
+        if (data instanceof Error) throw new Error(data.message);
+        chunks.push(data.choices[0]!.delta);
+      }
+
+      expect(chunks).toEqual([{ role: "assistant", content: "Final answer." }]);
+    });
   });
 
   describe("fromChatCompletionsAssistantMessage", () => {
@@ -498,7 +580,7 @@ describe("Chat Completions Converters", () => {
             },
           ],
         }),
-      ).toThrow(/Unsupported image media type/);
+      ).toThrow(/Unsupported image media type/u);
     });
 
     test("should convert input_audio content parts to file user content", () => {

--- a/src/endpoints/chat-completions/converters.ts
+++ b/src/endpoints/chat-completions/converters.ts
@@ -668,8 +668,25 @@ export const toChatCompletionsAssistantMessage = (
     }
   }
 
+  // OpenAI-compatible providers normally expose reasoning in `content`, but
+  // keep the response converter compatible with providers that populate the
+  // AI SDK result's normalized final-step reasoning field instead.
+  if (reasoningDetails.length === 0) {
+    for (const part of result.finalStep.reasoning ?? []) {
+      if (part.type === "reasoning") {
+        reasoningDetails.push(
+          toReasoningDetail(part, `reasoning-${crypto.randomUUID()}`, reasoningDetails.length),
+        );
+      }
+    }
+  }
+
   if (result.finalStep.reasoningText) {
     message.reasoning = result.finalStep.reasoningText;
+  } else if (reasoningDetails.length > 0) {
+    message.reasoning = reasoningDetails
+      .flatMap((detail) => (detail.type === "reasoning.text" && detail.text ? [detail.text] : []))
+      .join("");
   }
 
   if (reasoningDetails.length > 0) {

--- a/src/models/google/presets.test.ts
+++ b/src/models/google/presets.test.ts
@@ -7,6 +7,7 @@ import {
   geminiEmbedding2,
   gemma31b,
   gemma4E4b,
+  gemma426bA4b,
   gemma,
   gemini,
 } from "./presets";
@@ -119,6 +120,16 @@ test("gemma4E4b > should expose audio+image input with vertex provider", () => {
       capabilities: ["tool_call", "structured_output", "temperature"],
       context: 131072,
       providers: ["vertex"],
+    },
+  });
+});
+
+test("gemma426bA4b > should advertise reasoning capability", () => {
+  expect(gemma426bA4b()).toMatchObject({
+    "google/gemma-4-26b-a4b": {
+      capabilities: ["reasoning", "tool_call", "structured_output", "temperature"],
+      context: 262144,
+      providers: ["vertex", "deepinfra"],
     },
   });
 });

--- a/src/providers/vertex/middleware.test.ts
+++ b/src/providers/vertex/middleware.test.ts
@@ -118,21 +118,24 @@ for (const { name, vertex, expected } of vertexGemmaThinkingCases) {
   });
 }
 
-test("vertexGemma4ThinkingMiddleware > is registered only for gemma-4", () => {
+test("vertexGemma4ThinkingMiddleware > is registered only for Vertex MaaS", () => {
   expect(modelMiddlewareMatcher.for("google/gemma-4-26b-a4b", "vertex.maas")).toContain(
     vertexGemma4ThinkingMiddleware,
   );
-  expect(modelMiddlewareMatcher.for("openai/gpt-oss-120b-maas", "vertex.maas")).not.toContain(
+  expect(modelMiddlewareMatcher.for("openai/gpt-oss-120b-maas", "vertex.maas")).toContain(
     vertexGemma4ThinkingMiddleware,
   );
-  expect(modelMiddlewareMatcher.for("google/gemma-3-27b", "vertex.maas")).not.toContain(
+  expect(modelMiddlewareMatcher.for("google/gemma-3-27b", "deepinfra")).not.toContain(
     vertexGemma4ThinkingMiddleware,
   );
 });
 
 test("vertexGemma4ThinkingMiddleware > enable_thinking reaches the provider", async () => {
   const chain = modelMiddlewareMatcher.for("google/gemma-4-26b-a4b", "vertex.maas.chat");
-  const model = new MockLanguageModelV4({ modelId: "google/gemma-4-26b-a4b-it-maas" });
+  const model = new MockLanguageModelV4({
+    provider: "vertex.maas.chat",
+    modelId: "google/gemma-4-26b-a4b-it-maas",
+  });
 
   const params = await chain.reduce(
     async (acc, { transformParams }) => {
@@ -149,5 +152,55 @@ test("vertexGemma4ThinkingMiddleware > enable_thinking reaches the provider", as
 
   expect(params.providerOptions).toEqual({
     vertex: { chat_template_kwargs: { enable_thinking: true } },
+  });
+});
+
+test("vertexGemma4ThinkingMiddleware > does not translate other MaaS models", async () => {
+  const chain = modelMiddlewareMatcher.for("openai/gpt-oss-120b", "vertex.maas.chat");
+  const model = new MockLanguageModelV4({
+    provider: "vertex.maas.chat",
+    modelId: "openai/gpt-oss-120b-maas",
+  });
+
+  const params = await chain.reduce(
+    async (acc, { transformParams }) => {
+      const current = await acc;
+      return transformParams
+        ? transformParams({ type: "generate", params: current, model })
+        : current;
+    },
+    Promise.resolve({
+      prompt: [],
+      providerOptions: { unknown: { reasoning: { enabled: true } } },
+    } as LanguageModelV4CallOptions),
+  );
+
+  expect(params.providerOptions).toEqual({
+    vertex: { reasoning: { enabled: true } },
+  });
+});
+
+test("vertexGemma4ThinkingMiddleware > does not translate reasoning for non-Vertex providers", async () => {
+  const chain = modelMiddlewareMatcher.for("google/gemma-4-26b-a4b", "deepinfra");
+  const model = new MockLanguageModelV4({
+    provider: "deepinfra",
+    modelId: "google/gemma-4-26b-a4b-it",
+  });
+
+  const params = await chain.reduce(
+    async (acc, { transformParams }) => {
+      const current = await acc;
+      return transformParams
+        ? transformParams({ type: "generate", params: current, model })
+        : current;
+    },
+    Promise.resolve({
+      prompt: [],
+      providerOptions: { unknown: { reasoning: { enabled: true } } },
+    } as LanguageModelV4CallOptions),
+  );
+
+  expect(params.providerOptions).toEqual({
+    deepinfra: { reasoning: { enabled: true } },
   });
 });

--- a/src/providers/vertex/middleware.ts
+++ b/src/providers/vertex/middleware.ts
@@ -70,11 +70,18 @@ modelMiddlewareMatcher.useForProvider(["google.vertex.*"], {
 export const vertexGemma4ThinkingMiddleware: LanguageModelMiddleware = {
   specificationVersion: "v3",
   // oxlint-disable-next-line require-await
-  transformParams: async ({ params }) => {
+  transformParams: async ({ params, model }) => {
+    // MaaS uses the OpenAI-compatible provider, whose generic forwarding
+    // middleware runs before this provider middleware. Restrict the mapping to
+    // the routed native model so the same catalog entry remains unchanged on
+    // other providers.
+    if (model.modelId !== "google/gemma-4-26b-a4b-it-maas") return params;
+
     const vertex = params.providerOptions?.["vertex"];
     if (!vertex || typeof vertex !== "object") return params;
 
     const reasoning = vertex["reasoning"] as ChatCompletionsReasoningConfig | undefined;
+
     if (!reasoning) return params;
 
     // Normalization drops `enabled: true` when no effort/budget is set,
@@ -87,6 +94,6 @@ export const vertexGemma4ThinkingMiddleware: LanguageModelMiddleware = {
   },
 };
 
-modelMiddlewareMatcher.useForModel(["google/gemma-4-*"], {
+modelMiddlewareMatcher.useForProvider(["vertex.maas", "vertex.maas.*"], {
   language: [vertexGemma4ThinkingMiddleware],
 });


### PR DESCRIPTION
## Summary

- Add the Gemma 4 26B A4B preset with reasoning capabilities and Vertex/DeepInfra providers.
- Preserve normalized reasoning separately from final response content in chat completions.
- Scope Vertex thinking middleware to the routed Vertex MaaS Gemma model.
- Add converter, preset, and middleware coverage.

## Testing

- Added unit tests for reasoning conversion, streaming deltas, preset metadata, and provider middleware behavior.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Gemma 4 26B A4B model, including reasoning capabilities through Vertex and DeepInfra.
  * Improved reasoning responses by preserving and displaying final-step reasoning when available.
  * Added separate streaming updates for reasoning and response text.

* **Bug Fixes**
  * Limited Vertex reasoning-option mapping to supported models, preventing unintended changes for other providers and models.
  * Improved handling of unsupported-image error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->